### PR TITLE
chore: add missing peer dep testing-library/dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss7-compat": "^2.0.4",
+    "@testing-library/dom": "^8.9.1",
     "@types/qrcode.react": "^1.0.1",
     "@types/react-router-dom": "^5.1.7",
     "autoprefixer": "^9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,6 +2299,20 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/dom@^8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.9.1.tgz#d6bf8ad9e1699be0e0e0e818fc211b41e511ad08"
+  integrity sha512-jXM+FKo5BZA/2WtcsoTGuDs810J3ewQ2yq59Gxd2heux5jr8lo2DnTAl3JWVwAlg2/DcWSYqKY5pi9v0g8hvhw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.6"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^5.14.1":
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"


### PR DESCRIPTION
Avoid warning during `yarn install`:  
```sh
warning " > @testing-library/user-event@13.2.1" has unmet peer dependency "@testing-library/dom@>=7.21.4".
```