### PR TITLE
feat(sendLn): add very basic validation aka babysteps react #50

### DIFF
--- a/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { I18nextProvider } from "react-i18next";
+import i18n from "../../../../i18n/test_config";
+import SendLN from "./SendLN";
+
+const basicProps = {
+  balance: "123456",
+  onConfirm: () => {},
+  onChangeInvoice: () => {},
+};
+
+describe("SendLN", () => {
+  it("renders", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SendLN {...basicProps} />
+      </I18nextProvider>
+    );
+
+    expect(
+      await screen.findByText("wallet.send_lightning")
+    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("wallet.invoice")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "wallet.send" })
+    ).toBeInTheDocument();
+  });
+
+  it("validates the input", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SendLN {...basicProps} />
+      </I18nextProvider>
+    );
+
+    const invoiceInput = await screen.findByLabelText("wallet.invoice");
+
+    expect(
+      await screen.findByRole("button", { name: "wallet.send" })
+    ).not.toBeDisabled();
+
+    // validates empty value
+    userEvent.click(await screen.findByRole("button", { name: "wallet.send" }));
+    expect(invoiceInput).toHaveClass("input-error");
+    expect(
+      await screen.findByText("forms.validation.lnInvoice.required")
+    ).toBeInTheDocument();
+
+    // validates LN invoice format
+    userEvent.type(invoiceInput, "not a lightning invoice");
+    expect(invoiceInput).toHaveClass("input-error");
+    expect(
+      await screen.findByText("forms.validation.lnInvoice.patternMismatch")
+    ).toBeInTheDocument();
+
+    // let's valid invoice pass
+    userEvent.clear(invoiceInput);
+    userEvent.type(invoiceInput, "lnbc123");
+    expect(
+      await screen.findByRole("button", { name: "wallet.send" })
+    ).not.toBeDisabled();
+    expect(invoiceInput).not.toHaveClass("input-error");
+  });
+});

--- a/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
@@ -12,52 +12,79 @@ const basicProps = {
 };
 
 describe("SendLN", () => {
-  it("renders", async () => {
+  beforeEach(() => {
     render(
       <I18nextProvider i18n={i18n}>
         <SendLN {...basicProps} />
       </I18nextProvider>
     );
+  });
 
+  test("render", async () => {
     expect(
       await screen.findByText("wallet.send_lightning")
     ).toBeInTheDocument();
     expect(await screen.findByLabelText("wallet.invoice")).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "wallet.send" })
-    ).toBeInTheDocument();
+    ).not.toBeDisabled();
   });
 
-  it("validates the input", async () => {
-    render(
-      <I18nextProvider i18n={i18n}>
-        <SendLN {...basicProps} />
-      </I18nextProvider>
-    );
-
+  test("validates the input for empty value", async () => {
     const invoiceInput = await screen.findByLabelText("wallet.invoice");
 
     expect(
       await screen.findByRole("button", { name: "wallet.send" })
     ).not.toBeDisabled();
 
-    // validates empty value
     userEvent.click(await screen.findByRole("button", { name: "wallet.send" }));
     expect(invoiceInput).toHaveClass("input-error");
     expect(
       await screen.findByText("forms.validation.lnInvoice.required")
     ).toBeInTheDocument();
+  });
 
-    // validates LN invoice format
-    userEvent.type(invoiceInput, "not a lightning invoice");
+  test("validates the input for LN invoice format", async () => {
+    const invoiceInput = await screen.findByLabelText("wallet.invoice");
+
+    userEvent.type(invoiceInput, "123456789abc");
     expect(invoiceInput).toHaveClass("input-error");
     expect(
       await screen.findByText("forms.validation.lnInvoice.patternMismatch")
     ).toBeInTheDocument();
 
-    // let's valid invoice pass
     userEvent.clear(invoiceInput);
-    userEvent.type(invoiceInput, "lnbc123");
+    userEvent.type(invoiceInput, "lnbc");
+    expect(invoiceInput).toHaveClass("input-error");
+    expect(
+      await screen.findByText("forms.validation.lnInvoice.patternMismatch")
+    ).toBeInTheDocument();
+
+    userEvent.clear(invoiceInput);
+    userEvent.type(invoiceInput, "lntb");
+    expect(invoiceInput).toHaveClass("input-error");
+    expect(
+      await screen.findByText("forms.validation.lnInvoice.patternMismatch")
+    ).toBeInTheDocument();
+  });
+
+  test("valid LN invoice passes", async () => {
+    const invoiceInput = await screen.findByLabelText("wallet.invoice");
+
+    userEvent.type(
+      invoiceInput,
+      "lnbcrt500u1psc09t8pp5jxn0qqx5rnv4zhc7tvftlfr2p7lq25cm8af0h2k5vcy0cfkgwugqdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2sp5n9uetwjh0wua595fqtce8r3n5lnqk6f603en2k4wx8p988vl5haq9qy9qsqtgsp7ery57uge8jh66sgu42rttsnpyygdtjx05r5sexjdljrfa3hd9mj4z8w3xhp2nz30fa79jcug3chsw2g7jk75zwel33qsl455nqpx9p6z5"
+    );
+    expect(
+      await screen.findByRole("button", { name: "wallet.send" })
+    ).not.toBeDisabled();
+    expect(invoiceInput).not.toHaveClass("input-error");
+
+    userEvent.clear(invoiceInput);
+    userEvent.type(
+      invoiceInput,
+      "lntb500u1psc09t8pp5jxn0qqx5rnv4zhc7tvftlfr2p7lq25cm8af0h2k5vcy0cfkgwugqdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2sp5n9uetwjh0wua595fqtce8r3n5lnqk6f603en2k4wx8p988vl5haq9qy9qsqtgsp7ery57uge8jh66sgu42rttsnpyygdtjx05r5sexjdljrfa3hd9mj4z8w3xhp2nz30fa79jcug3chsw2g7jk75zwel33qsl455nqpx9p6z5"
+    );
     expect(
       await screen.findByRole("button", { name: "wallet.send" })
     ).not.toBeDisabled();

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, FormEvent, useContext } from "react";
+import { ChangeEvent, FC, FormEvent, useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 
@@ -7,13 +7,20 @@ const SendLn: FC<SendLnProps> = (props) => {
   const { balance, onChangeInvoice, onConfirm } = props;
   const { t } = useTranslation();
 
+  const [isFormValid, setIsFormValid] = useState(true);
+
+  const validateInput = (event: ChangeEvent<HTMLInputElement>) => {
+    // TODO: check wallet balance
+    setIsFormValid(event.target.validity.valid)
+  }
+
   return (
     <form onSubmit={onConfirm}>
       <h3 className="text-xl font-bold">{t("wallet.send_lightning")}</h3>
-      <div className="my-5">
+      <p className="my-5">
         <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
         {balance} {appCtx.unit}
-      </div>
+      </p>
       <label className="label-underline" htmlFor="invoiceInput">
         {t("wallet.invoice")}
       </label>
@@ -21,10 +28,14 @@ const SendLn: FC<SendLnProps> = (props) => {
         id="invoiceInput"
         type="text"
         onChange={onChangeInvoice}
-        className="input-underline"
+        onBlur={validateInput}
+        required
+        pattern="(lnbc|lntb|lntbs|lnbcrt)\w+"
+        className={isFormValid ? "input-underline":"input-error"}
+
       />
-      <button type="submit" className="bd-button p-3 my-3">
-        Submit
+      <button type="submit" className="bd-button p-3 my-3" disabled={!isFormValid}>
+        {t("wallet.send")}
       </button>
     </form>
   );

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -72,7 +72,7 @@ const SendLn: FC<SendLnProps> = (props) => {
         type="text"
         onChange={onChange}
         required
-        pattern="(lnbc|lntb|lntbs|lnbcrt)\w+"
+        pattern="(lnbc|lntb)\w+"
         className={isFormValid ? "input-underline" : "input-error"}
         placeholder="lnbc..."
       />

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, FC, FormEvent, useContext, useState } from "react";
+import {
+  ChangeEvent,
+  FC,
+  FormEvent,
+  useContext,
+  useState,
+  useRef,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 
@@ -7,34 +14,76 @@ const SendLn: FC<SendLnProps> = (props) => {
   const { balance, onChangeInvoice, onConfirm } = props;
   const { t } = useTranslation();
 
+  const invoiceInput = useRef<HTMLInputElement>(null);
   const [isFormValid, setIsFormValid] = useState(true);
+  const [errorMessage, setErrorMessage] = useState("");
 
-  const validateInput = (event: ChangeEvent<HTMLInputElement>) => {
-    // TODO: check wallet balance
-    setIsFormValid(event.target.validity.valid)
-  }
+  const validateInput = (validity: HTMLInputElement["validity"]) => {
+    setIsFormValid(validity.valid);
+    setErrorMessage("");
+
+    if (validity.valueMissing) {
+      setErrorMessage(t("forms.validation.lnInvoice.required"));
+      return false;
+    }
+
+    if (validity.patternMismatch) {
+      setErrorMessage(t("forms.validation.lnInvoice.patternMismatch"));
+      return false;
+    }
+
+    return true;
+  };
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    validateInput(event.target.validity);
+    onChangeInvoice(event);
+  };
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validity = invoiceInput?.current?.validity;
+
+    if (validity) {
+      const isFormValid = validateInput(validity);
+
+      if (isFormValid) {
+        onConfirm(event);
+      }
+    }
+  };
 
   return (
-    <form onSubmit={onConfirm}>
+    <form onSubmit={onSubmit} noValidate>
       <h3 className="text-xl font-bold">{t("wallet.send_lightning")}</h3>
+
       <p className="my-5">
         <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
         {balance} {appCtx.unit}
       </p>
+
       <label className="label-underline" htmlFor="invoiceInput">
         {t("wallet.invoice")}
       </label>
+
       <input
         id="invoiceInput"
+        ref={invoiceInput}
         type="text"
-        onChange={onChangeInvoice}
-        onBlur={validateInput}
+        onChange={onChange}
         required
         pattern="(lnbc|lntb|lntbs|lnbcrt)\w+"
-        className={isFormValid ? "input-underline":"input-error"}
-
+        className={isFormValid ? "input-underline" : "input-error"}
+        placeholder="lnbc..."
       />
-      <button type="submit" className="bd-button p-3 my-3" disabled={!isFormValid}>
+
+      <p className="text-red-500">{errorMessage}</p>
+
+      <button
+        type="submit"
+        className="bd-button p-3 my-3"
+        disabled={!isFormValid}
+      >
         {t("wallet.send")}
       </button>
     </form>

--- a/src/components/Shared/SendModal/SendModal.tsx
+++ b/src/components/Shared/SendModal/SendModal.tsx
@@ -105,6 +105,7 @@ const SendModal: FC<SendModalProps> = (props) => {
       >
         {t("settings.change")} <SwitchIcon className="inline-block p-0.5" />
       </button>
+
       {lnTransaction && (
         <SendLn
           onChangeInvoice={changeInvoiceHandler}
@@ -112,6 +113,7 @@ const SendModal: FC<SendModalProps> = (props) => {
           balance={lnBalance}
         />
       )}
+
       {!lnTransaction && (
         <SendOnChain
           balance={onchainBalance}

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -75,6 +75,14 @@
       "txid": "Transaktions ID",
       "tx_details": "Transaktionsdetails",
       "transactions": "Transaktionen"
+    },
+    "forms": {
+      "validation": {
+        "lnInvoice": {
+          "required": "Bitte gib eine Lightning invoice ein",
+          "patternMismatch": "Falsches invoice format"
+        }
+      }
     }
   }
 }

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -95,6 +95,14 @@
       "confirm": "Confirm",
       "language": "Language",
       "curr_lang": "Current language"
+    },
+    "forms": {
+      "validation": {
+        "lnInvoice": {
+          "required": "Please input a Lightning invoice",
+          "patternMismatch": "Wrong invoice format"
+        }
+      }
     }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+/*
+  https://stackoverflow.com/questions/47607602/how-to-add-a-tailwind-css-rule-to-css-checker
+  regarding the linting issues in this file
+*/
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -12,6 +17,11 @@
 
 .input-underline {
   @apply mt-0 block w-full px-0.5 border-0 border-b-2 bg-transparent outline-none border-gray-200 focus:ring-0 focus:border-yellow-500 text-black dark:text-white;
+}
+
+.input-error {
+  @apply input-underline;
+  @apply border-red-500;
 }
 
 .bd-card {

--- a/src/index.css
+++ b/src/index.css
@@ -21,7 +21,7 @@
 
 .input-error {
   @apply input-underline;
-  @apply border-red-500;
+  @apply border-red-500 focus:border-red-500;
 }
 
 .bd-card {


### PR DESCRIPTION
First tiny peak into validation

![image](https://user-images.githubusercontent.com/1016218/139243348-573b8a34-c577-49a8-8bee-a070b75ab3e6.png)


- Decided against a lib to learn more and get back into React again (and to make you happy :P)
- How should validation-info for the user be handled?
   - Is a `title`-attribute enough?
   - A tooltip
   - A hint-box that just says what the input expect
- Checking the balance for a LN payment before sending seems only possible by decoding the (pasted) invoice first.
   Not sure how this can be done in a simple way. Do people use libs for that?
   - I saw [Alex Bosworth created one](https://github.com/alexbosworth/invoices#byteencoderequest). Could give it a try.
   - Other suggestion I got was this: https://github.com/Xtrimmer/lndecode/blob/master/js/decoder.js  
      Could just copy and use it as well.
  - Is this related or covered by #64 ?
- The (partly more complicated) onchain-form can be tackled after first feedback
   - How should validation-infos for the user be handled on this form?

TODO
- [x] test

Question: Did you chose to use on [uncontrolled inputs](https://reactjs.org/docs/uncontrolled-components.html) purpose? Instead of using [controlled inputs](https://reactjs.org/docs/forms.html#controlled-components)