### PR TITLE
Feat/50 onchainsend validation AKA rework all inputs/forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.14.3",
+    "react-hook-form": "^7.20.2",
     "react-qr-code": "^2.0.3",
     "react-router-dom": "^5.2.0",
     "react-toastify": "^8.1.0"

--- a/src/components/Shared/AmountInput/AmountInput.module.css
+++ b/src/components/Shared/AmountInput/AmountInput.module.css
@@ -1,8 +1,0 @@
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-input[type="number"] {
-  -moz-appearance: textfield;
-}

--- a/src/components/Shared/AmountInput/AmountInput.tsx
+++ b/src/components/Shared/AmountInput/AmountInput.tsx
@@ -13,6 +13,7 @@ const AmountInput: FC<AmountInputProps> = (props) => {
       <label htmlFor="amount" className="label-underline">
         {t("wallet.amount")}
       </label>
+
       <div className="flex flex-row">
         <input
           id="amount"
@@ -21,7 +22,9 @@ const AmountInput: FC<AmountInputProps> = (props) => {
           className="w-8/12 text-right input-underline mr-3 pr-5"
           value={props.amount}
           onChange={props.onChangeAmount}
+          required
         />
+
         <span
           className="flex justify-center items-center w-4/12 p-1 rounded shadow-md dark:bg-gray-600"
           onClick={appCtx.toggleUnit}

--- a/src/components/Shared/AmountInput/AmountInput.tsx
+++ b/src/components/Shared/AmountInput/AmountInput.tsx
@@ -1,38 +1,40 @@
-import { ChangeEventHandler, FC, useContext } from "react";
+import { useContext } from "react";
+import type { FC } from "react";
+import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { ReactComponent as SwitchIcon } from "../../../assets/switch-vertical.svg";
 import { AppContext } from "../../../store/app-context";
-import styles from "./AmountInput.module.css";
+import InputField from "../InputField/InputField";
 
 const AmountInput: FC<AmountInputProps> = (props) => {
   const { t } = useTranslation();
-  const appCtx = useContext(AppContext);
 
-  return (
-    <>
-      <label htmlFor="amount" className="label-underline">
-        {t("wallet.amount")}
-      </label>
+  const ButtonToggleUnit: FC = () => {
+    const appCtx = useContext(AppContext);
 
-      <div className="flex flex-row">
-        <input
-          id="amount"
-          type="number"
-          style={styles}
-          className="w-8/12 text-right input-underline mr-3 pr-5"
-          value={props.amount}
-          onChange={props.onChangeAmount}
-          required
-        />
-
+    return (
+      <>
         <span
-          className="flex justify-center items-center w-4/12 p-1 rounded shadow-md dark:bg-gray-600"
+          className="flex justify-center items-center w-4/12 ml-6 p-1 rounded shadow-md dark:bg-gray-600"
           onClick={appCtx.toggleUnit}
         >
           {appCtx.unit}
           <SwitchIcon className="h-5 w-5 text-black dark:text-white" />
         </span>
-      </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <InputField
+        {...props.register}
+        type="number"
+        label={t("wallet.amount")}
+        errorMessage={props.errorMessage}
+        value={`${props.amount}`}
+        inputRightElement={<ButtonToggleUnit />}
+      />
     </>
   );
 };
@@ -41,5 +43,6 @@ export default AmountInput;
 
 export interface AmountInputProps {
   amount: number;
-  onChangeAmount: ChangeEventHandler<HTMLInputElement>;
+  register: UseFormRegisterReturn;
+  errorMessage?: FieldError;
 }

--- a/src/components/Shared/InputField/InputField.test.tsx
+++ b/src/components/Shared/InputField/InputField.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { I18nextProvider } from "react-i18next";
+import i18n from "../../../i18n/test_config";
+import InputField from "./InputField";
+import type { InputFieldProps } from "./InputField";
+
+const basicProps: InputFieldProps = {
+  label: "Banana Label",
+  name: "bananaName",
+  ref: () => undefined,
+  onChange: async () => undefined,
+  onBlur: async () => undefined,
+};
+
+describe("InputField", () => {
+  test("render with placeholder", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <InputField {...basicProps} placeholder="A yellow fruit" />
+      </I18nextProvider>
+    );
+
+    const input = await screen.findByLabelText("Banana Label");
+    await waitFor(() => expect(input).toHaveClass("input-underline"));
+    expect(input).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("A yellow fruit")).toBeInTheDocument();
+  });
+
+  test("render with error-message", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <InputField
+          {...basicProps}
+          errorMessage={{ type: "required", message: "Banana required!" }}
+        />
+      </I18nextProvider>
+    );
+
+    const input = await screen.findByLabelText("Banana Label");
+    await waitFor(() => expect(input).toHaveClass("input-error"));
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText("Banana required!")).toBeInTheDocument();
+  });
+
+  test("prop inputRightAddon", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <InputField {...basicProps} inputRightAddon="Right add-on text" />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText("Right add-on text")).toBeInTheDocument();
+  });
+
+  test("prop inputRightElement", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <InputField
+          {...basicProps}
+          inputRightElement={<button>Click me!</button>}
+        />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText("Click me!")).toBeInTheDocument();
+  });
+});

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,97 +1,54 @@
 import { forwardRef } from "react";
-import type { ChangeEvent, Ref } from "react";
-import type { FieldError } from "react-hook-form";
+import type { Ref } from "react";
+import type {
+  FieldError,
+  UseFormRegisterReturn,
+  ChangeHandler,
+} from "react-hook-form";
 
 const InputField = forwardRef(
-  (props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
-    const {
-      label,
+  (
+    {
       name,
+      label,
       errorMessage,
       placeholder,
-    } = props;
-
+      onChange,
+      ...rest
+    }: InputFieldProps,
+    ref: Ref<HTMLInputElement>
+  ) => {
+    console.log("errorMessage", errorMessage);
     return (
       <>
-                <label htmlFor={name}>{label}</label>
-        <input id={name} name={name} placeholder={placeholder} />
-        {errorMessage?.type === 'required' && errorMessage?.message}
+        <label className="label-underline" htmlFor={name}>
+          {label}
+        </label>
 
+        <div className="flex">
+          <input
+            id={name}
+            name={name}
+            placeholder={placeholder}
+            {...rest}
+            ref={ref}
+            onChange={onChange}
+            className={`
+               ${errorMessage ? "input-error" : "input-underline"}
+             `}
+          />
+        </div>
+
+        {errorMessage && <p className="text-red-500">{errorMessage.message}</p>}
       </>
     );
   }
 );
 
-// const InputField = forwardRef(
-//   (props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
-//     const {
-//       errorMessage,
-//       id,
-//       inputRightAddon,
-//       isFormValid,
-//       label,
-//       onChange,
-//       pattern,
-//       placeholder,
-//       required,
-//       textAlign,
-//       type,
-//       value,
-//     } = props;
-
-//     return (
-//       <>
-//         <label className="label-underline" htmlFor={id}>
-//           {label}
-//         </label>
-
-//         <div className="flex">
-//           <input
-//             className={`
-//               ${isFormValid ? "input-underline" : "input-error"}
-//               ${textAlign === "right" ?? "text-right"}
-//               ${inputRightAddon ?? "w-7/12"}
-//             `}
-//             id={id}
-//             onChange={onChange}
-//             pattern={pattern}
-//             placeholder={placeholder}
-//             ref={ref}
-//             required={required}
-//             type={type}
-//             value={value}
-//           />
-
-//           {inputRightAddon && (
-//             <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
-//           )}
-//         </div>
-
-//         {errorMessage && <p className="text-red-500">{errorMessage}</p>}
-//       </>
-//     );
-//   }
-// );
-
 export default InputField;
 
-// export interface InputFieldProps {
-//   errorMessage?: string;
-//   id: string;
-//   inputRightAddon?: string;
-//   isFormValid?: boolean;
-//   label: string;
-//   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-//   pattern?: string;
-//   placeholder?: string;
-//   required?: boolean;
-//   textAlign?: "right";
-//   type: "text" | "number";
-//   value?: string | number;
-// }
-export interface InputFieldProps {
+export interface InputFieldProps extends UseFormRegisterReturn {
   label: string;
-  name: string;
   errorMessage?: FieldError;
   placeholder?: string;
 }

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from "react";
 import type { Ref } from "react";
 import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
+import { HTMLInputTypeAttribute } from "react";
 
 const InputField = forwardRef(
   (
@@ -9,12 +10,14 @@ const InputField = forwardRef(
       label,
       errorMessage,
       placeholder,
+      value,
+      inputRightAddon,
+      type,
       onChange,
       ...rest
     }: InputFieldProps,
     ref: Ref<HTMLInputElement>
   ) => {
-    console.log("errorMessage", errorMessage);
     return (
       <>
         <label className="label-underline" htmlFor={name}>
@@ -25,6 +28,8 @@ const InputField = forwardRef(
           <input
             id={name}
             name={name}
+            value={value}
+            type={type}
             placeholder={placeholder}
             {...rest}
             ref={ref}
@@ -33,6 +38,10 @@ const InputField = forwardRef(
                ${errorMessage ? "input-error" : "input-underline"}
              `}
           />
+
+          {inputRightAddon && (
+            <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
+          )}
         </div>
 
         {errorMessage && <p className="text-red-500">{errorMessage.message}</p>}
@@ -47,4 +56,7 @@ export interface InputFieldProps extends UseFormRegisterReturn {
   label: string;
   errorMessage?: FieldError;
   placeholder?: string;
+  value?: string;
+  inputRightAddon?: string;
+  type?: HTMLInputTypeAttribute;
 }

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -38,8 +38,8 @@ const InputField = forwardRef(
             onChange={onChange}
             className={`
                ${errorMessage ? "input-error" : "input-underline"}
-               ${(textAlign === "right" || type === "number") && "text-right"}
-               ${(inputRightAddon || inputRightElement) && "w-7/12"}
+               ${textAlign === "right" || type === "number" ? "text-right" : ""}
+               ${inputRightAddon || inputRightElement ? "w-7/12" : ""}
                `}
           />
 

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import type { FC, Ref } from "react";
+import type { ReactElement, Ref } from "react";
 import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
 import { HTMLInputTypeAttribute } from "react";
 
@@ -50,7 +50,9 @@ const InputField = forwardRef(
           {inputRightElement}
         </div>
 
-        {errorMessage && <p className="text-red-500">{errorMessage.message}</p>}
+        {errorMessage && (
+          <p className="text-left text-red-500">{errorMessage.message}</p>
+        )}
       </>
     );
   }
@@ -64,7 +66,7 @@ export interface InputFieldProps extends UseFormRegisterReturn {
   placeholder?: string;
   value?: string;
   inputRightAddon?: string;
-  inputRightElement?: any | string;
+  inputRightElement?: ReactElement | string;
   textAlign?: "right";
   type?: HTMLInputTypeAttribute;
 }

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,10 +1,6 @@
 import { forwardRef } from "react";
 import type { Ref } from "react";
-import type {
-  FieldError,
-  UseFormRegisterReturn,
-  ChangeHandler,
-} from "react-hook-form";
+import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
 
 const InputField = forwardRef(
   (

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,0 +1,53 @@
+import { forwardRef } from "react";
+import type { ChangeEvent, Ref } from "react";
+
+const InputField = forwardRef(
+  (props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
+    const {
+      errorMessage,
+      id,
+      isFormValid,
+      label,
+      onChange,
+      pattern,
+      placeholder,
+      required,
+      type,
+    } = props;
+
+    return (
+      <>
+        <label className="label-underline" htmlFor={id}>
+          {label}
+        </label>
+
+        <input
+          className={isFormValid ? "input-underline" : "input-error"}
+          id={id}
+          onChange={onChange}
+          pattern={pattern}
+          placeholder={placeholder}
+          ref={ref}
+          required={required}
+          type={type}
+        />
+
+        <p className="text-red-500">{errorMessage}</p>
+      </>
+    );
+  }
+);
+
+export default InputField;
+
+export interface InputFieldProps {
+  errorMessage?: string;
+  id: string;
+  isFormValid?: boolean;
+  label: string;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  pattern?: string;
+  placeholder?: string;
+  required?: boolean;
+  type: "text" | "number";
+}

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,70 +1,97 @@
 import { forwardRef } from "react";
 import type { ChangeEvent, Ref } from "react";
+import type { FieldError } from "react-hook-form";
 
 const InputField = forwardRef(
   (props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
     const {
-      errorMessage,
-      id,
-      inputRightAddon,
-      isFormValid,
       label,
-      onChange,
-      pattern,
+      name,
+      errorMessage,
       placeholder,
-      required,
-      textAlign,
-      type,
-      value,
     } = props;
 
     return (
       <>
-        <label className="label-underline" htmlFor={id}>
-          {label}
-        </label>
+                <label htmlFor={name}>{label}</label>
+        <input id={name} name={name} placeholder={placeholder} />
+        {errorMessage?.type === 'required' && errorMessage?.message}
 
-        <div className="flex">
-          <input
-            className={`
-              ${isFormValid ? "input-underline" : "input-error"}
-              ${textAlign === "right" ?? "text-right"}
-              ${inputRightAddon ?? "w-7/12"}
-            `}
-            id={id}
-            onChange={onChange}
-            pattern={pattern}
-            placeholder={placeholder}
-            ref={ref}
-            required={required}
-            type={type}
-            value={value}
-          />
-
-          {inputRightAddon && (
-            <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
-          )}
-        </div>
-
-        {errorMessage && <p className="text-red-500">{errorMessage}</p>}
       </>
     );
   }
 );
 
+// const InputField = forwardRef(
+//   (props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
+//     const {
+//       errorMessage,
+//       id,
+//       inputRightAddon,
+//       isFormValid,
+//       label,
+//       onChange,
+//       pattern,
+//       placeholder,
+//       required,
+//       textAlign,
+//       type,
+//       value,
+//     } = props;
+
+//     return (
+//       <>
+//         <label className="label-underline" htmlFor={id}>
+//           {label}
+//         </label>
+
+//         <div className="flex">
+//           <input
+//             className={`
+//               ${isFormValid ? "input-underline" : "input-error"}
+//               ${textAlign === "right" ?? "text-right"}
+//               ${inputRightAddon ?? "w-7/12"}
+//             `}
+//             id={id}
+//             onChange={onChange}
+//             pattern={pattern}
+//             placeholder={placeholder}
+//             ref={ref}
+//             required={required}
+//             type={type}
+//             value={value}
+//           />
+
+//           {inputRightAddon && (
+//             <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
+//           )}
+//         </div>
+
+//         {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+//       </>
+//     );
+//   }
+// );
+
 export default InputField;
 
+// export interface InputFieldProps {
+//   errorMessage?: string;
+//   id: string;
+//   inputRightAddon?: string;
+//   isFormValid?: boolean;
+//   label: string;
+//   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+//   pattern?: string;
+//   placeholder?: string;
+//   required?: boolean;
+//   textAlign?: "right";
+//   type: "text" | "number";
+//   value?: string | number;
+// }
 export interface InputFieldProps {
-  errorMessage?: string;
-  id: string;
-  inputRightAddon?: string;
-  isFormValid?: boolean;
   label: string;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  pattern?: string;
+  name: string;
+  errorMessage?: FieldError;
   placeholder?: string;
-  required?: boolean;
-  textAlign?: "right";
-  type: "text" | "number";
-  value?: string | number;
 }

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -6,13 +6,16 @@ const InputField = forwardRef(
     const {
       errorMessage,
       id,
+      inputRightAddon,
       isFormValid,
       label,
       onChange,
       pattern,
       placeholder,
       required,
+      textAlign,
       type,
+      value,
     } = props;
 
     return (
@@ -21,18 +24,29 @@ const InputField = forwardRef(
           {label}
         </label>
 
-        <input
-          className={isFormValid ? "input-underline" : "input-error"}
-          id={id}
-          onChange={onChange}
-          pattern={pattern}
-          placeholder={placeholder}
-          ref={ref}
-          required={required}
-          type={type}
-        />
+        <div className="flex">
+          <input
+            className={`
+              ${isFormValid ? "input-underline" : "input-error"}
+              ${textAlign === "right" ?? "text-right"}
+              ${inputRightAddon ?? "w-7/12"}
+            `}
+            id={id}
+            onChange={onChange}
+            pattern={pattern}
+            placeholder={placeholder}
+            ref={ref}
+            required={required}
+            type={type}
+            value={value}
+          />
 
-        <p className="text-red-500">{errorMessage}</p>
+          {inputRightAddon && (
+            <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
+          )}
+        </div>
+
+        {errorMessage && <p className="text-red-500">{errorMessage}</p>}
       </>
     );
   }
@@ -43,11 +57,14 @@ export default InputField;
 export interface InputFieldProps {
   errorMessage?: string;
   id: string;
+  inputRightAddon?: string;
   isFormValid?: boolean;
   label: string;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   pattern?: string;
   placeholder?: string;
   required?: boolean;
+  textAlign?: "right";
   type: "text" | "number";
+  value?: string | number;
 }

--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import type { Ref } from "react";
+import type { FC, Ref } from "react";
 import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
 import { HTMLInputTypeAttribute } from "react";
 
@@ -12,7 +12,9 @@ const InputField = forwardRef(
       placeholder,
       value,
       inputRightAddon,
+      inputRightElement,
       type,
+      textAlign,
       onChange,
       ...rest
     }: InputFieldProps,
@@ -36,12 +38,16 @@ const InputField = forwardRef(
             onChange={onChange}
             className={`
                ${errorMessage ? "input-error" : "input-underline"}
-             `}
+               ${(textAlign === "right" || type === "number") && "text-right"}
+               ${(inputRightAddon || inputRightElement) && "w-7/12"}
+               `}
           />
 
           {inputRightAddon && (
             <div className="w-5/12 text-sm break-words">{inputRightAddon}</div>
           )}
+
+          {inputRightElement}
         </div>
 
         {errorMessage && <p className="text-red-500">{errorMessage.message}</p>}
@@ -58,5 +64,7 @@ export interface InputFieldProps extends UseFormRegisterReturn {
   placeholder?: string;
   value?: string;
   inputRightAddon?: string;
+  inputRightElement?: any | string;
+  textAlign?: "right";
   type?: HTMLInputTypeAttribute;
 }

--- a/src/components/Shared/ReceiveModal/ReceiveModal.tsx
+++ b/src/components/Shared/ReceiveModal/ReceiveModal.tsx
@@ -180,7 +180,7 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
                   })}
                   label={t("tx.comment")}
                   value={comment}
-                  placeholder="Optional comment"
+                  placeholder={t("tx.comment_placeholder")}
                 />
               </div>
             </div>

--- a/src/components/Shared/ReceiveModal/ReceiveModal.tsx
+++ b/src/components/Shared/ReceiveModal/ReceiveModal.tsx
@@ -79,6 +79,7 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
       {showLnInvoice && (
         <div className="text-xl font-bold">{t("wallet.create_invoice_ln")}</div>
       )}
+
       {!showLnInvoice && (
         <div className="text-xl font-bold">{t("wallet.fund")}</div>
       )}
@@ -87,6 +88,7 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
           <label htmlFor="lightning" className={`${radioStyles} ${lnStyle}`}>
             {t("home.lightning")}
           </label>
+
           <input
             id="lightning"
             type="radio"
@@ -100,6 +102,7 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
           <label htmlFor="onchain" className={`${radioStyles} ${walletStyle}`}>
             {t("wallet.fund_onchain")}
           </label>
+
           <input
             id="onchain"
             type="radio"
@@ -125,6 +128,7 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
           </p>
         </>
       )}
+
       <form
         className="w-full flex flex-col items-center"
         onSubmit={generateInvoiceHandler}

--- a/src/components/Shared/ReceiveModal/ReceiveModal.tsx
+++ b/src/components/Shared/ReceiveModal/ReceiveModal.tsx
@@ -195,26 +195,6 @@ const ReceiveModal: FC<ReceiveModalProps> = (props) => {
               {t("wallet.create_invoice")}
             </button>
           )}
-
-          {address && (
-            <>
-              <article className="flex flex-row items-center">
-                <div className="w-11/12 overflow-x-auto m-2">{address}</div>
-                <Tooltip
-                  overlay={
-                    <div>
-                      {addressCopied
-                        ? t("wallet.copied")
-                        : t("wallet.copy_clipboard")}
-                    </div>
-                  }
-                  placement="top"
-                >
-                  <ClipboardIcon className="w-6 h-6" onClick={copyAddress} />
-                </Tooltip>
-              </article>
-            </>
-          )}
         </fieldset>
       </form>
 

--- a/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
@@ -1,4 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { I18nextProvider } from "react-i18next";

--- a/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
@@ -38,7 +38,7 @@ describe("SendLN", () => {
     ).not.toBeDisabled();
 
     userEvent.click(await screen.findByRole("button", { name: "wallet.send" }));
-    expect(invoiceInput).toHaveClass("input-error");
+    await waitFor(() => expect(invoiceInput).toHaveClass("input-error"));
     expect(
       await screen.findByText("forms.validation.lnInvoice.required")
     ).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("SendLN", () => {
     const invoiceInput = await screen.findByLabelText("wallet.invoice");
 
     userEvent.type(invoiceInput, "123456789abc");
-    expect(invoiceInput).toHaveClass("input-error");
+    await waitFor(() => expect(invoiceInput).toHaveClass("input-error"));
     expect(
       await screen.findByText("forms.validation.lnInvoice.patternMismatch")
     ).toBeInTheDocument();

--- a/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.test.tsx
@@ -4,8 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../../../../i18n/test_config";
 import SendLN from "./SendLN";
+import type { SendLnProps } from "./SendLN";
 
-const basicProps = {
+const basicProps: SendLnProps = {
   balance: "123456",
   onConfirm: () => {},
   onChangeInvoice: () => {},

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -15,7 +15,6 @@ const SendLn: FC<SendLnProps> = (props) => {
   const { t } = useTranslation();
 
   interface IFormInputs {
-    firstName: string;
     invoiceInput: string;
   }
 

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useContext } from "react";
+import { FC, useContext } from "react";
 
 import type { ChangeEvent } from "react";
 
@@ -27,19 +27,7 @@ const SendLn: FC<SendLnProps> = (props) => {
     mode: "onChange",
   });
 
-  const onSubmit: SubmitHandler<IFormInputs> = (data) => console.log(data);
-
-  // const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-  //   validateInput(event.target.validity);
-  //   onChangeInvoice(event);
-  // };
-  // const onChangeFoo = (event: SyntheticBaseEvent ) => {
-  //   console.log('onChangeFoo', event.target.native);
-  // };
-
-  // const onSubmit = (event: FormEvent<HTMLFormElement>) => {
-  //       onConfirm(event);
-  // };
+  const onSubmit: SubmitHandler<IFormInputs> = (_data) => onConfirm();
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -57,7 +45,7 @@ const SendLn: FC<SendLnProps> = (props) => {
             value: /(lnbc|lntb)\w+/i,
             message: t("forms.validation.lnInvoice.patternMismatch"),
           },
-          // onChange: onChangeFoo
+          onChange: onChangeInvoice,
         })}
         label={t("wallet.invoice")}
         errorMessage={errors.invoiceInput}
@@ -78,6 +66,6 @@ export default SendLn;
 
 export interface SendLnProps {
   balance: string;
-  onConfirm: (event: FormEvent) => void;
+  onConfirm: () => void;
   onChangeInvoice: (event: ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -1,63 +1,63 @@
 import {
-  ChangeEvent,
   FC,
   FormEvent,
   useContext,
   useState,
   useRef,
 } from "react";
+
+import type { ChangeEvent, Ref } from "react";
+
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 import InputField from "../../InputField/InputField";
+
+import { SubmitHandler, useForm, FieldError, UseFormRegister, Path, RegisterOptions} from "react-hook-form";
+import { forwardRef } from "react";
 
 const SendLn: FC<SendLnProps> = (props) => {
   const appCtx = useContext(AppContext);
   const { balance, onChangeInvoice, onConfirm } = props;
   const { t } = useTranslation();
 
-  const invoiceInput = useRef<HTMLInputElement>(null);
-  const [isFormValid, setIsFormValid] = useState(true);
-  const [errorMessage, setErrorMessage] = useState("");
+  
+  interface IFormInputs {
+    firstName: string;
+    // lastName: string;
+  }
 
-  const validateInput = (validity: HTMLInputElement["validity"]) => {
-    setIsFormValid(validity.valid);
-    setErrorMessage("");
+  interface InputFieldProps {
+    label: string;
+    name: Path<IFormInputs>;
+    errorMessage?: FieldError;
+    register: UseFormRegister<IFormInputs>;
+    rules: RegisterOptions;
+  }
+  
+  const { register, handleSubmit, formState: { errors } } = useForm<IFormInputs>({
+    mode: 'onChange',
+  });
 
-    if (validity.valueMissing) {
-      setErrorMessage(t("forms.validation.lnInvoice.required"));
-      return false;
-    }
+  console.log('errors', errors)
 
-    if (validity.patternMismatch) {
-      setErrorMessage(t("forms.validation.lnInvoice.patternMismatch"));
-      return false;
-    }
 
-    return true;
-  };
+  const onSubmit: SubmitHandler<IFormInputs> = data => console.log(data);
 
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    validateInput(event.target.validity);
-    onChangeInvoice(event);
-  };
 
-  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
-    console.log("FORM event", invoiceInput);
+  const MyInput = forwardRef((props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
+    const { name, label, errorMessage, register, rules, ...rest} = props;
 
-    event.preventDefault();
-    const validity = invoiceInput?.current?.validity;
-
-    if (validity) {
-      const isFormValid = validateInput(validity);
-
-      if (isFormValid) {
-        onConfirm(event);
-      }
-    }
-  };
+    return (
+      <>
+        <label htmlFor={name}>{label}</label>
+        <input id={name}  placeholder="Jane" {...register(name, rules)}  {...rest}/>
+        {errorMessage?.type === 'required' && errorMessage?.message}
+      </>
+    );
+  });
 
   return (
-    <form onSubmit={onSubmit} noValidate>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <h3 className="text-xl font-bold">{t("wallet.send_lightning")}</h3>
 
       <p className="my-5">
@@ -65,28 +65,142 @@ const SendLn: FC<SendLnProps> = (props) => {
         {balance} {appCtx.unit}
       </p>
 
-      <InputField
-        id="invoiceInput"
-        ref={invoiceInput}
-        label={t("wallet.invoice")}
-        pattern="(lnbc|lntb)\w+"
-        placeholder="lnbc..."
-        type="text"
-        onChange={onChange}
-        isFormValid={isFormValid}
-        errorMessage={errorMessage}
-        required={true}
-      />
+      
+      <div>
+          <MyInput
+            name="firstName"
+            label="First Name"
+            register={register}
+            // {...register("firstName")}
+            // {...register("firstName", { required: "Das brauchen wir" })}
+            rules={{ required: "Das brauchen wir du eule" }}
+            errorMessage={errors.firstName}
+            />
+        </div>
+        
+        {/* <div>
+          <InputField
+            id="lastName"
+            label="Last Name"
+            {...register("lastName", { required: "Das brauchen wir 123" })}
+            errorMessage={errors.lastName}
+          />
+        </div> */}
 
       <button
         type="submit"
         className="bd-button p-3 my-3"
-        disabled={!isFormValid}
+        // disabled={!isValid}
       >
         {t("wallet.send")}
       </button>
     </form>
   );
+
+  // return (
+  //   <div className="App">
+  //     <form onSubmit={handleSubmit(onSubmit)}>
+       
+
+  //       <div>
+  //         <MyInput
+  //           id="firstName"
+  //           name="firstName"
+  //           label="First Name"
+  //           register={register}
+  //           // {...register("firstName")}
+  //           // {...register("firstName", { required: "Das brauchen wir" })}
+  //           rules={{ required: "Das brauchen wir du eule" }}
+  //           errorMessage={errors.firstName}
+  //           />
+  //       </div>
+        
+  //       {/* <div>
+  //         <InputField
+  //           id="lastName"
+  //           label="Last Name"
+  //           {...register("lastName", { required: "Das brauchen wir 123" })}
+  //           errorMessage={errors.lastName}
+  //         />
+  //       </div> */}
+
+  //       <button type="submit">Submit</button>
+  //     </form>
+  //   </div>
+  // );
+
+  // const invoiceInput = useRef<HTMLInputElement>(null);
+  // const [isFormValid, setIsFormValid] = useState(true);
+  // const [errorMessage, setErrorMessage] = useState("");
+
+  // const validateInput = (validity: HTMLInputElement["validity"]) => {
+  //   setIsFormValid(validity.valid);
+  //   setErrorMessage("");
+
+  //   if (validity.valueMissing) {
+  //     setErrorMessage(t("forms.validation.lnInvoice.required"));
+  //     return false;
+  //   }
+
+  //   if (validity.patternMismatch) {
+  //     setErrorMessage(t("forms.validation.lnInvoice.patternMismatch"));
+  //     return false;
+  //   }
+
+  //   return true;
+  // };
+
+  // const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+  //   validateInput(event.target.validity);
+  //   onChangeInvoice(event);
+  // };
+
+  // const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+  //   console.log("FORM event", invoiceInput);
+
+  //   event.preventDefault();
+  //   const validity = invoiceInput?.current?.validity;
+
+  //   if (validity) {
+  //     const isFormValid = validateInput(validity);
+
+  //     if (isFormValid) {
+  //       onConfirm(event);
+  //     }
+  //   }
+  // };
+
+  // return (
+  //   <form onSubmit={onSubmit} noValidate>
+  //     <h3 className="text-xl font-bold">{t("wallet.send_lightning")}</h3>
+
+  //     <p className="my-5">
+  //       <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
+  //       {balance} {appCtx.unit}
+  //     </p>
+
+  //     <InputField
+  //       id="invoiceInput"
+  //       ref={invoiceInput}
+  //       label={t("wallet.invoice")}
+  //       pattern="(lnbc|lntb)\w+"
+  //       placeholder="lnbc..."
+  //       type="text"
+  //       onChange={onChange}
+  //       isFormValid={isFormValid}
+  //       errorMessage={errorMessage}
+  //       required={true}
+  //     />
+
+  //     <button
+  //       type="submit"
+  //       className="bd-button p-3 my-3"
+  //       disabled={!isFormValid}
+  //     >
+  //       {t("wallet.send")}
+  //     </button>
+  //   </form>
+  // );
 };
 
 export default SendLn;

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -1,60 +1,45 @@
-import {
-  FC,
-  FormEvent,
-  useContext,
-  useState,
-  useRef,
-} from "react";
+import { FC, FormEvent, useContext } from "react";
 
-import type { ChangeEvent, Ref } from "react";
+import type { ChangeEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 import InputField from "../../InputField/InputField";
 
-import { SubmitHandler, useForm, FieldError, UseFormRegister, Path, RegisterOptions} from "react-hook-form";
-import { forwardRef } from "react";
+import { useForm } from "react-hook-form";
+import type { SubmitHandler } from "react-hook-form";
 
 const SendLn: FC<SendLnProps> = (props) => {
   const appCtx = useContext(AppContext);
   const { balance, onChangeInvoice, onConfirm } = props;
   const { t } = useTranslation();
 
-  
   interface IFormInputs {
     firstName: string;
-    // lastName: string;
+    invoiceInput: string;
   }
 
-  interface InputFieldProps {
-    label: string;
-    name: Path<IFormInputs>;
-    errorMessage?: FieldError;
-    register: UseFormRegister<IFormInputs>;
-    rules: RegisterOptions;
-  }
-  
-  const { register, handleSubmit, formState: { errors } } = useForm<IFormInputs>({
-    mode: 'onChange',
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, submitCount },
+  } = useForm<IFormInputs>({
+    mode: "onChange",
   });
 
-  console.log('errors', errors)
+  const onSubmit: SubmitHandler<IFormInputs> = (data) => console.log(data);
 
+  // const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+  //   validateInput(event.target.validity);
+  //   onChangeInvoice(event);
+  // };
+  // const onChangeFoo = (event: SyntheticBaseEvent ) => {
+  //   console.log('onChangeFoo', event.target.native);
+  // };
 
-  const onSubmit: SubmitHandler<IFormInputs> = data => console.log(data);
-
-
-  const MyInput = forwardRef((props: InputFieldProps, ref: Ref<HTMLInputElement>) => {
-    const { name, label, errorMessage, register, rules, ...rest} = props;
-
-    return (
-      <>
-        <label htmlFor={name}>{label}</label>
-        <input id={name}  placeholder="Jane" {...register(name, rules)}  {...rest}/>
-        {errorMessage?.type === 'required' && errorMessage?.message}
-      </>
-    );
-  });
+  // const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+  //       onConfirm(event);
+  // };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -65,142 +50,28 @@ const SendLn: FC<SendLnProps> = (props) => {
         {balance} {appCtx.unit}
       </p>
 
-      
-      <div>
-          <MyInput
-            name="firstName"
-            label="First Name"
-            register={register}
-            // {...register("firstName")}
-            // {...register("firstName", { required: "Das brauchen wir" })}
-            rules={{ required: "Das brauchen wir du eule" }}
-            errorMessage={errors.firstName}
-            />
-        </div>
-        
-        {/* <div>
-          <InputField
-            id="lastName"
-            label="Last Name"
-            {...register("lastName", { required: "Das brauchen wir 123" })}
-            errorMessage={errors.lastName}
-          />
-        </div> */}
+      <InputField
+        {...register("invoiceInput", {
+          required: t("forms.validation.lnInvoice.required") as string,
+          pattern: {
+            value: /(lnbc|lntb)\w+/i,
+            message: t("forms.validation.lnInvoice.patternMismatch"),
+          },
+          // onChange: onChangeFoo
+        })}
+        label={t("wallet.invoice")}
+        errorMessage={errors.invoiceInput}
+      />
 
       <button
         type="submit"
         className="bd-button p-3 my-3"
-        // disabled={!isValid}
+        disabled={submitCount > 0 && !isValid}
       >
         {t("wallet.send")}
       </button>
     </form>
   );
-
-  // return (
-  //   <div className="App">
-  //     <form onSubmit={handleSubmit(onSubmit)}>
-       
-
-  //       <div>
-  //         <MyInput
-  //           id="firstName"
-  //           name="firstName"
-  //           label="First Name"
-  //           register={register}
-  //           // {...register("firstName")}
-  //           // {...register("firstName", { required: "Das brauchen wir" })}
-  //           rules={{ required: "Das brauchen wir du eule" }}
-  //           errorMessage={errors.firstName}
-  //           />
-  //       </div>
-        
-  //       {/* <div>
-  //         <InputField
-  //           id="lastName"
-  //           label="Last Name"
-  //           {...register("lastName", { required: "Das brauchen wir 123" })}
-  //           errorMessage={errors.lastName}
-  //         />
-  //       </div> */}
-
-  //       <button type="submit">Submit</button>
-  //     </form>
-  //   </div>
-  // );
-
-  // const invoiceInput = useRef<HTMLInputElement>(null);
-  // const [isFormValid, setIsFormValid] = useState(true);
-  // const [errorMessage, setErrorMessage] = useState("");
-
-  // const validateInput = (validity: HTMLInputElement["validity"]) => {
-  //   setIsFormValid(validity.valid);
-  //   setErrorMessage("");
-
-  //   if (validity.valueMissing) {
-  //     setErrorMessage(t("forms.validation.lnInvoice.required"));
-  //     return false;
-  //   }
-
-  //   if (validity.patternMismatch) {
-  //     setErrorMessage(t("forms.validation.lnInvoice.patternMismatch"));
-  //     return false;
-  //   }
-
-  //   return true;
-  // };
-
-  // const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-  //   validateInput(event.target.validity);
-  //   onChangeInvoice(event);
-  // };
-
-  // const onSubmit = (event: FormEvent<HTMLFormElement>) => {
-  //   console.log("FORM event", invoiceInput);
-
-  //   event.preventDefault();
-  //   const validity = invoiceInput?.current?.validity;
-
-  //   if (validity) {
-  //     const isFormValid = validateInput(validity);
-
-  //     if (isFormValid) {
-  //       onConfirm(event);
-  //     }
-  //   }
-  // };
-
-  // return (
-  //   <form onSubmit={onSubmit} noValidate>
-  //     <h3 className="text-xl font-bold">{t("wallet.send_lightning")}</h3>
-
-  //     <p className="my-5">
-  //       <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
-  //       {balance} {appCtx.unit}
-  //     </p>
-
-  //     <InputField
-  //       id="invoiceInput"
-  //       ref={invoiceInput}
-  //       label={t("wallet.invoice")}
-  //       pattern="(lnbc|lntb)\w+"
-  //       placeholder="lnbc..."
-  //       type="text"
-  //       onChange={onChange}
-  //       isFormValid={isFormValid}
-  //       errorMessage={errorMessage}
-  //       required={true}
-  //     />
-
-  //     <button
-  //       type="submit"
-  //       className="bd-button p-3 my-3"
-  //       disabled={!isFormValid}
-  //     >
-  //       {t("wallet.send")}
-  //     </button>
-  //   </form>
-  // );
 };
 
 export default SendLn;

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -41,7 +41,7 @@ const SendLn: FC<SendLnProps> = (props) => {
         {...register("invoiceInput", {
           required: t("forms.validation.lnInvoice.required") as string,
           pattern: {
-            value: /(lnbc|lntb)\w+/i,
+            value: /^(lnbc|lntb)\w+/i,
             message: t("forms.validation.lnInvoice.patternMismatch"),
           },
           onChange: onChangeInvoice,

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -48,6 +48,7 @@ const SendLn: FC<SendLnProps> = (props) => {
         })}
         label={t("wallet.invoice")}
         errorMessage={errors.invoiceInput}
+        placeholder="lnbc..."
       />
 
       <button

--- a/src/components/Shared/SendModal/SendLN/SendLN.tsx
+++ b/src/components/Shared/SendModal/SendLN/SendLN.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
+import InputField from "../../InputField/InputField";
 
 const SendLn: FC<SendLnProps> = (props) => {
   const appCtx = useContext(AppContext);
@@ -41,6 +42,8 @@ const SendLn: FC<SendLnProps> = (props) => {
   };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    console.log("FORM event", invoiceInput);
+
     event.preventDefault();
     const validity = invoiceInput?.current?.validity;
 
@@ -62,22 +65,18 @@ const SendLn: FC<SendLnProps> = (props) => {
         {balance} {appCtx.unit}
       </p>
 
-      <label className="label-underline" htmlFor="invoiceInput">
-        {t("wallet.invoice")}
-      </label>
-
-      <input
+      <InputField
         id="invoiceInput"
         ref={invoiceInput}
+        label={t("wallet.invoice")}
+        pattern="(lnbc|lntb)\w+"
+        placeholder="lnbc..."
         type="text"
         onChange={onChange}
-        required
-        pattern="(lnbc|lntb)\w+"
-        className={isFormValid ? "input-underline" : "input-error"}
-        placeholder="lnbc..."
+        isFormValid={isFormValid}
+        errorMessage={errorMessage}
+        required={true}
       />
-
-      <p className="text-red-500">{errorMessage}</p>
 
       <button
         type="submit"

--- a/src/components/Shared/SendModal/SendModal.tsx
+++ b/src/components/Shared/SendModal/SendModal.tsx
@@ -27,8 +27,7 @@ const SendModal: FC<SendModalProps> = (props) => {
   const [comment, setComment] = useState("");
 
   // TODO: handle error
-  const confirmLnHandler = async (event: FormEvent) => {
-    event.preventDefault();
+  const confirmLnHandler = async () => {
     const resp = await instance.get(
       "/lightning/decode-pay-req?pay_req=" + invoice
     );

--- a/src/components/Shared/SendModal/SendModal.tsx
+++ b/src/components/Shared/SendModal/SendModal.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, FormEvent, useContext, useState } from "react";
+import { ChangeEvent, FC, useContext, useState } from "react";
 import ModalDialog from "../../../container/ModalDialog/ModalDialog";
 import { AppContext } from "../../../store/app-context";
 import { instance } from "../../../util/interceptor";
@@ -36,8 +36,7 @@ const SendModal: FC<SendModalProps> = (props) => {
     setConfirm(true);
   };
 
-  const confirmOnChainHandler = (event: FormEvent) => {
-    event.preventDefault();
+  const confirmOnChainHandler = () => {
     setConfirm(true);
   };
 

--- a/src/components/Shared/SendModal/SendModal.tsx
+++ b/src/components/Shared/SendModal/SendModal.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from "react-i18next";
 import {
   convertMSatToBtc,
   convertMSatToSat,
-  convertSatToBtc,
   convertToString,
 } from "../../../util/format";
 
@@ -68,11 +67,6 @@ const SendModal: FC<SendModalProps> = (props) => {
     setInvoice(event.target.value);
   };
 
-  const onchainBalance =
-    appCtx.unit === "BTC"
-      ? convertToString(appCtx.unit, convertSatToBtc(props.onchainBalance))
-      : convertToString(appCtx.unit, props.onchainBalance);
-
   const lnBalance =
     appCtx.unit === "BTC"
       ? convertToString(appCtx.unit, convertMSatToBtc(props.lnBalance))
@@ -114,7 +108,7 @@ const SendModal: FC<SendModalProps> = (props) => {
 
       {!lnTransaction && (
         <SendOnChain
-          balance={onchainBalance}
+          balance={props.onchainBalance}
           address={address}
           onChangeAddress={changeAddressHandler}
           amount={amount}

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { I18nextProvider } from "react-i18next";

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
@@ -9,7 +9,7 @@ import type { SendOnChainProps } from "./SendOnChain";
 const basicProps: SendOnChainProps = {
   address: "",
   amount: 12,
-  balance: "",
+  balance: 100,
   comment: "",
   fee: "",
   onChangeAddress: () => {},
@@ -79,6 +79,19 @@ describe("SendOnChain", () => {
     await waitFor(() => expect(addressInput).toHaveClass("input-error"));
     expect(
       screen.getByText("forms.validation.chainAddress.patternMismatch")
+    ).toBeInTheDocument();
+  });
+
+  test("validates amount is lower than balance", async () => {
+    const amountInput = screen.getByLabelText(
+      "wallet.amount"
+    ) as HTMLInputElement;
+
+    userEvent.clear(amountInput);
+    userEvent.type(amountInput, "999");
+    await waitFor(() => expect(amountInput).toHaveClass("input-error"));
+    expect(
+      screen.getByText("forms.validation.chainAmount.max")
     ).toBeInTheDocument();
   });
 

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { I18nextProvider } from "react-i18next";
+import i18n from "../../../../i18n/test_config";
+import SendOnChain from "./SendOnChain";
+import type { SendOnChainProps } from "./SendOnChain";
+
+const basicProps: SendOnChainProps = {
+  address: "",
+  amount: 12,
+  balance: "",
+  comment: "",
+  fee: "",
+  onChangeAddress: () => {},
+  onChangeAmount: () => {},
+  onChangeComment: () => {},
+  onChangeFee: () => {},
+  onConfirm: () => {},
+};
+
+describe("SendOnChain", () => {
+  beforeEach(() => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SendOnChain {...basicProps} />
+      </I18nextProvider>
+    );
+  });
+
+  test("render", async () => {
+    expect(screen.getByText("wallet.send_onchain")).toBeInTheDocument();
+
+    expect(screen.getByLabelText("wallet.address")).toBeInTheDocument();
+    expect(screen.getByLabelText("wallet.amount")).toBeInTheDocument();
+    expect(screen.getByLabelText("tx.fee")).toBeInTheDocument();
+    expect(screen.getByLabelText("tx.comment")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: "wallet.confirm" })
+    ).not.toBeDisabled();
+  });
+
+  test("validates the input for empty value", async () => {
+    expect(
+      screen.getByRole("button", { name: "wallet.confirm" })
+    ).not.toBeDisabled();
+
+    userEvent.click(screen.getByRole("button", { name: "wallet.confirm" }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("wallet.address")).toHaveClass("input-error")
+    );
+    expect(
+      screen.getByText("forms.validation.chainAddress.required")
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText("tx.fee")).toHaveClass("input-error")
+    );
+    expect(
+      screen.getByText("forms.validation.chainFee.required")
+    ).toBeInTheDocument();
+  });
+
+  test("validates the address-input for BTC address format", async () => {
+    const addressInput = screen.getByLabelText(
+      "wallet.address"
+    ) as HTMLInputElement;
+
+    userEvent.clear(addressInput);
+    userEvent.type(addressInput, "abc123456789");
+    await waitFor(() => expect(addressInput).toHaveClass("input-error"));
+    expect(
+      screen.getByText("forms.validation.chainAddress.patternMismatch")
+    ).toBeInTheDocument();
+
+    userEvent.clear(addressInput);
+    userEvent.type(addressInput, "bc1");
+    await waitFor(() => expect(addressInput).toHaveClass("input-error"));
+    expect(
+      screen.getByText("forms.validation.chainAddress.patternMismatch")
+    ).toBeInTheDocument();
+  });
+
+  test("valid form passes", async () => {
+    const addressInput = screen.getByLabelText(
+      "wallet.address"
+    ) as HTMLInputElement;
+    const feeInput = screen.getByLabelText("tx.fee") as HTMLInputElement;
+
+    userEvent.type(addressInput, "bc1123456789");
+    expect(addressInput).not.toHaveClass("input-error");
+
+    userEvent.type(feeInput, "1");
+    expect(feeInput).not.toHaveClass("input-error");
+
+    expect(
+      screen.getByRole("button", { name: "wallet.confirm" })
+    ).not.toBeDisabled();
+  });
+});

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -2,20 +2,21 @@ import { ChangeEvent, FC, FormEvent, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 import AmountInput from "../../AmountInput/AmountInput";
+import InputField from "../../InputField/InputField";
 
 const SendOnChain: FC<SendOnChainProps> = (props) => {
   const { t } = useTranslation();
   const appCtx = useContext(AppContext);
   const {
-    balance,
     address,
-    onChangeAddress,
     amount,
-    onChangeAmount,
-    fee,
-    onChangeFee,
+    balance,
     comment,
+    fee,
+    onChangeAddress,
+    onChangeAmount,
     onChangeComment,
+    onChangeFee,
     onConfirm,
   } = props;
 
@@ -30,19 +31,16 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
 
       <div className="my-5 flex flex-col justify-center text-center items-center">
         <div className="w-full md:w-10/12 py-1">
-          <label htmlFor="address" className="label-underline">
-            {t("wallet.address")}
-          </label>
-
-          <input
+          <InputField
+            isFormValid={true}
             id="address"
-            type="text"
-            className="w-full input-underline"
-            value={address}
-            onChange={onChangeAddress}
-            required
-            // @TODO: is this corect?
+            label={t("wallet.address")}
             pattern="(1|3|bc1)\w+"
+            placeholder="bc..."
+            type="text"
+            onChange={onChangeAddress}
+            required={true}
+            value={address}
           />
         </div>
 
@@ -51,35 +49,28 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
         </div>
 
         <div className="w-full md:w-10/12 py-1">
-          <label htmlFor="fee" className="label-underline">
-            {t("tx.fee")}
-          </label>
-
-          <div className="flex">
-            <input
-              id="fee"
-              type="number"
-              className="w-7/12 input-underline text-right"
-              value={fee}
-              onChange={onChangeFee}
-              required
-            />
-            <div className="w-5/12 text-sm break-words">sat / vByte</div>
-          </div>
+          <InputField
+            isFormValid={true}
+            id="fee"
+            label={t("tx.fee")}
+            type="number"
+            onChange={onChangeFee}
+            required={true}
+            value={fee}
+            inputRightAddon="sat / vByte"
+          />
         </div>
 
         <div className="w-full md:w-10/12 py-1">
-          <label htmlFor="comment" className="label-underline">
-            {t("tx.comment")}
-          </label>
-
-          <input
+          <InputField
+            isFormValid={true}
             id="comment"
-            type="text"
+            label={t("tx.comment")}
             placeholder="Optional comment"
-            className="input-underline"
-            value={comment}
+            type="text"
             onChange={onChangeComment}
+            required={true}
+            value={comment}
           />
         </div>
       </div>
@@ -99,14 +90,14 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
 export default SendOnChain;
 
 export interface SendOnChainProps {
-  balance: string;
   address: string;
-  onChangeAddress: (event: ChangeEvent<HTMLInputElement>) => void;
   amount: number;
-  onChangeAmount: (event: ChangeEvent<HTMLInputElement>) => void;
-  fee: string;
-  onChangeFee: (event: ChangeEvent<HTMLInputElement>) => void;
+  balance: string;
   comment: string;
+  fee: string;
+  onChangeAddress: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChangeAmount: (event: ChangeEvent<HTMLInputElement>) => void;
   onChangeComment: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChangeFee: (event: ChangeEvent<HTMLInputElement>) => void;
   onConfirm: (event: FormEvent) => void;
 }

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from "react";
 
-import type { ChangeEvent, FormEvent } from "react";
+import type { ChangeEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
@@ -101,9 +101,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
               onChange: onChangeComment,
             })}
             label={t("tx.comment")}
-            errorMessage={errors.commentInput}
             value={comment}
-            inputRightAddon="sat / vByte"
             placeholder="Optional comment"
           />
         </div>

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -1,8 +1,20 @@
-import { ChangeEvent, FC, FormEvent, useContext } from "react";
+import { FC, useContext } from "react";
+
+import type { ChangeEvent, FormEvent } from "react";
+
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
 import AmountInput from "../../AmountInput/AmountInput";
 import InputField from "../../InputField/InputField";
+
+import { useForm } from "react-hook-form";
+import type { SubmitHandler } from "react-hook-form";
+
+interface IFormInputs {
+  addressInput: string;
+  feeInput: number;
+  commentInput: string;
+}
 
 const SendOnChain: FC<SendOnChainProps> = (props) => {
   const { t } = useTranslation();
@@ -20,65 +32,80 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
     onConfirm,
   } = props;
 
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, submitCount },
+  } = useForm<IFormInputs>({
+    mode: "onChange",
+  });
+
+  const onSubmit: SubmitHandler<IFormInputs> = (_data) => onConfirm();
+
   return (
-    <form className="px-5" onSubmit={onConfirm}>
+    <form className="px-5" onSubmit={handleSubmit(onSubmit)}>
       <h3 className="text-xl font-bold">{t("wallet.send_onchain")}</h3>
 
-      <div className="my-5">
+      <p className="my-5">
         <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
         {balance} {appCtx.unit}
-      </div>
+      </p>
 
-      {/* <div className="my-5 flex flex-col justify-center text-center items-center">
+      <fieldset className="my-5 flex flex-col justify-center text-center items-center">
         <div className="w-full md:w-10/12 py-1">
           <InputField
-            isFormValid={true}
-            id="address"
-            label={t("wallet.address")}
-            pattern="(1|3|bc1)\w+"
+            {...register("addressInput", {
+              required: t("forms.validation.chainAddress.required") as string,
+              pattern: {
+                value: /(1|3|bc1)\w+/i,
+                message: t("forms.validation.chainAddress.patternMismatch"),
+              },
+              onChange: onChangeAddress,
+            })}
             placeholder="bc..."
-            type="text"
-            onChange={onChangeAddress}
-            required={true}
+            label={t("wallet.address")}
+            errorMessage={errors.addressInput}
             value={address}
           />
         </div>
 
         <div className="w-full md:w-10/12 py-1">
-          <AmountInput amount={amount} onChangeAmount={onChangeAmount} />
+          {/* <AmountInput amount={amount} onChangeAmount={onChangeAmount} /> */}
         </div>
 
         <div className="w-full md:w-10/12 py-1">
           <InputField
-            isFormValid={true}
-            id="fee"
+            {...register("feeInput", {
+              required: t("forms.validation.chainFee.required") as string,
+              onChange: onChangeFee,
+            })}
             label={t("tx.fee")}
-            type="number"
-            onChange={onChangeFee}
-            required={true}
+            errorMessage={errors.feeInput}
             value={fee}
             inputRightAddon="sat / vByte"
+            type="number"
           />
         </div>
 
         <div className="w-full md:w-10/12 py-1">
           <InputField
-            isFormValid={true}
-            id="comment"
+            {...register("commentInput", {
+              onChange: onChangeComment,
+            })}
             label={t("tx.comment")}
-            placeholder="Optional comment"
-            type="text"
-            onChange={onChangeComment}
-            required={true}
+            errorMessage={errors.commentInput}
             value={comment}
+            inputRightAddon="sat / vByte"
+            placeholder="Optional comment"
           />
         </div>
-      </div> */}
+      </fieldset>
 
       <div className="inline-block w-4/5 lg:w-3/12 align-top mb-5">
         <button
           type="submit"
-          className="text-center h-10 bg-yellow-500 hover:bg-yellow-400 dark:hover:bg-yellow-400 rounded-lg text-white w-full"
+          className="bd-button p-3 my-3"
+          disabled={submitCount > 0 && !isValid}
         >
           {t("wallet.confirm")}
         </button>
@@ -99,5 +126,5 @@ export interface SendOnChainProps {
   onChangeAmount: (event: ChangeEvent<HTMLInputElement>) => void;
   onChangeComment: (event: ChangeEvent<HTMLInputElement>) => void;
   onChangeFee: (event: ChangeEvent<HTMLInputElement>) => void;
-  onConfirm: (event: FormEvent) => void;
+  onConfirm: () => void;
 }

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -25,11 +25,6 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
 
   const appCtx = useContext(AppContext);
 
-  const balanceDecorated =
-    appCtx.unit === "BTC"
-      ? convertToString(appCtx.unit, convertSatToBtc(props.balance))
-      : convertToString(appCtx.unit, props.balance);
-
   const {
     address,
     amount,
@@ -43,6 +38,11 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
     onConfirm,
   } = props;
 
+  const balanceDecorated =
+    appCtx.unit === "BTC"
+      ? convertToString(appCtx.unit, convertSatToBtc(balance))
+      : convertToString(appCtx.unit, balance);
+
   const {
     register,
     handleSubmit,
@@ -52,8 +52,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
   });
 
   const onSubmit: SubmitHandler<IFormInputs> = (_data) => onConfirm();
-  console.log("balance", balance);
-  console.log("balance -1", +balance - 1);
+
   return (
     <form className="px-5" onSubmit={handleSubmit(onSubmit)}>
       <h3 className="text-xl font-bold">{t("wallet.send_onchain")}</h3>

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -29,7 +29,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
         {balance} {appCtx.unit}
       </div>
 
-      <div className="my-5 flex flex-col justify-center text-center items-center">
+      {/* <div className="my-5 flex flex-col justify-center text-center items-center">
         <div className="w-full md:w-10/12 py-1">
           <InputField
             isFormValid={true}
@@ -73,7 +73,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
             value={comment}
           />
         </div>
-      </div>
+      </div> */}
 
       <div className="inline-block w-4/5 lg:w-3/12 align-top mb-5">
         <button

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -58,12 +58,12 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
             {...register("addressInput", {
               required: t("forms.validation.chainAddress.required") as string,
               pattern: {
-                value: /(1|3|bc1)\w+/i,
+                value: /^(1|3|bc1)\w+/i,
                 message: t("forms.validation.chainAddress.patternMismatch"),
               },
               onChange: onChangeAddress,
             })}
-            placeholder="bc..."
+            placeholder="bc1..."
             label={t("wallet.address")}
             errorMessage={errors.addressInput}
             value={address}

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -58,7 +58,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
             {...register("addressInput", {
               required: t("forms.validation.chainAddress.required") as string,
               pattern: {
-                value: /^(1|3|bc1)\w+/i,
+                value: /^(1|3|bc1|tb1|tpub|bcrt)\w+/i,
                 message: t("forms.validation.chainAddress.patternMismatch"),
               },
               onChange: onChangeAddress,
@@ -102,7 +102,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
             })}
             label={t("tx.comment")}
             value={comment}
-            placeholder="Optional comment"
+            placeholder={t("tx.comment_placeholder")}
           />
         </div>
       </fieldset>

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -22,23 +22,30 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
   return (
     <form className="px-5" onSubmit={onConfirm}>
       <h3 className="text-xl font-bold">{t("wallet.send_onchain")}</h3>
+
       <div className="my-5">
         <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
         {balance} {appCtx.unit}
       </div>
+
       <div className="my-5 flex flex-col justify-center text-center items-center">
         <div className="w-full md:w-10/12 py-1">
           <label htmlFor="address" className="label-underline">
             {t("wallet.address")}
           </label>
+
           <input
             id="address"
             type="text"
             className="w-full input-underline"
             value={address}
             onChange={onChangeAddress}
+            required
+            // @TODO: is this corect?
+            pattern="(1|3|bc1)\w+"
           />
         </div>
+
         <div className="w-full md:w-10/12 py-1">
           <AmountInput amount={amount} onChangeAmount={onChangeAmount} />
         </div>
@@ -47,6 +54,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
           <label htmlFor="fee" className="label-underline">
             {t("tx.fee")}
           </label>
+
           <div className="flex">
             <input
               id="fee"
@@ -54,6 +62,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
               className="w-7/12 input-underline text-right"
               value={fee}
               onChange={onChangeFee}
+              required
             />
             <div className="w-5/12 text-sm break-words">sat / vByte</div>
           </div>
@@ -63,6 +72,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
           <label htmlFor="comment" className="label-underline">
             {t("tx.comment")}
           </label>
+
           <input
             id="comment"
             type="text"
@@ -73,6 +83,7 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
           />
         </div>
       </div>
+
       <div className="inline-block w-4/5 lg:w-3/12 align-top mb-5">
         <button
           type="submit"

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -4,6 +4,9 @@ import type { ChangeEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../../../../store/app-context";
+
+import { convertSatToBtc, convertToString } from "../../../../util/format";
+
 import AmountInput from "../../AmountInput/AmountInput";
 import InputField from "../../InputField/InputField";
 
@@ -19,7 +22,14 @@ interface IFormInputs {
 
 const SendOnChain: FC<SendOnChainProps> = (props) => {
   const { t } = useTranslation();
+
   const appCtx = useContext(AppContext);
+
+  const balanceDecorated =
+    appCtx.unit === "BTC"
+      ? convertToString(appCtx.unit, convertSatToBtc(props.balance))
+      : convertToString(appCtx.unit, props.balance);
+
   const {
     address,
     amount,
@@ -42,14 +52,15 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
   });
 
   const onSubmit: SubmitHandler<IFormInputs> = (_data) => onConfirm();
-
+  console.log("balance", balance);
+  console.log("balance -1", +balance - 1);
   return (
     <form className="px-5" onSubmit={handleSubmit(onSubmit)}>
       <h3 className="text-xl font-bold">{t("wallet.send_onchain")}</h3>
 
       <p className="my-5">
         <span className="font-bold">{t("wallet.balance")}:&nbsp;</span>
-        {balance} {appCtx.unit}
+        {balanceDecorated} {appCtx.unit}
       </p>
 
       <fieldset className="my-5 flex flex-col justify-center text-center items-center">
@@ -75,6 +86,10 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
             amount={amount}
             register={register("amountInput", {
               required: t("forms.validation.chainAmount.required") as string,
+              max: {
+                value: props.balance,
+                message: t("forms.validation.chainAmount.max"),
+              },
               onChange: onChangeAmount,
             })}
             errorMessage={errors.amountInput}
@@ -125,7 +140,7 @@ export default SendOnChain;
 export interface SendOnChainProps {
   address: string;
   amount: number;
-  balance: string;
+  balance: number;
   comment: string;
   fee: string;
   onChangeAddress: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
+++ b/src/components/Shared/SendModal/SendOnChain/SendOnChain.tsx
@@ -13,6 +13,7 @@ import type { SubmitHandler } from "react-hook-form";
 interface IFormInputs {
   addressInput: string;
   feeInput: number;
+  amountInput: number;
   commentInput: string;
 }
 
@@ -70,7 +71,14 @@ const SendOnChain: FC<SendOnChainProps> = (props) => {
         </div>
 
         <div className="w-full md:w-10/12 py-1">
-          {/* <AmountInput amount={amount} onChangeAmount={onChangeAmount} /> */}
+          <AmountInput
+            amount={amount}
+            register={register("amountInput", {
+              required: t("forms.validation.chainAmount.required") as string,
+              onChange: onChangeAmount,
+            })}
+            errorMessage={errors.amountInput}
+          />
         </div>
 
         <div className="w-full md:w-10/12 py-1">

--- a/src/container/ModalDialog/ModalDialog.tsx
+++ b/src/container/ModalDialog/ModalDialog.tsx
@@ -3,9 +3,9 @@ import { FC, useEffect, useCallback } from "react";
 import { ReactComponent as XIcon } from "../../assets/X.svg";
 
 const disableScroll = {
-  on: () => document.body.classList.add('overflow-y-hidden'),
-  off: () => document.body.classList.remove('overflow-y-hidden')
-}
+  on: () => document.body.classList.add("overflow-y-hidden"),
+  off: () => document.body.classList.remove("overflow-y-hidden"),
+};
 
 const ModalDialog: FC<ModalDialogProps> = (props) => {
   disableScroll.on();

--- a/src/container/ModalDialog/ModalDialog.tsx
+++ b/src/container/ModalDialog/ModalDialog.tsx
@@ -3,9 +3,9 @@ import { FC, useEffect, useCallback } from "react";
 import { ReactComponent as XIcon } from "../../assets/X.svg";
 
 const disableScroll = {
-  on: () => document.body.classList.add("overflow-y-hidden"),
-  off: () => document.body.classList.remove("overflow-y-hidden"),
-};
+  on: () => document.body.classList.add('overflow-y-hidden'),
+  off: () => document.body.classList.remove('overflow-y-hidden')
+}
 
 const ModalDialog: FC<ModalDialogProps> = (props) => {
   disableScroll.on();

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -83,8 +83,11 @@
           "patternMismatch": "Falsches invoice format"
         },
         "chainAddress": {
-          "required": "Bitte gib eine Bitocin Adresse ein",
+          "required": "Bitte gib eine Bitcoin Adresse ein",
           "patternMismatch": "Falsches Adress format"
+        },
+        "chainFee": {
+          "required": "Bitte gib eine Gebühr ein"
         }
       }
     }

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -88,7 +88,8 @@
           "patternMismatch": "Falsches Adress format"
         },
         "chainAmount": {
-          "required": "Bitte gib einen Betrag ein"
+          "required": "Bitte gib einen Betrag ein",
+          "max": "Dein Guthaben reicht nicht aus, um diesen Bertrag zu verschicken"
         },
         "chainFee": {
           "required": "Bitte gib eine Gebühr ein"

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -1,24 +1,5 @@
 {
   "translation": {
-    "login": {
-      "enter_pass": "Passwort B eingeben",
-      "enter_pass_placeholder": "Passwort B",
-      "error": "Ein Fehler ist aufgetreten",
-      "invalid_pass": "Ungültiges Passwort",
-      "login": "Anmelden"
-    },
-    "settings": {
-      "language": "Sprache",
-      "curr_lang": "Aktuelle Sprache",
-      "confirm": "Bestätigen",
-      "cancel": "Abbrechen",
-      "shutdown": "Herunterfahren",
-      "reboot": "Neu starten",
-      "change": "Ändern",
-      "new_pw": "Neues Passwort",
-      "old_pw": "Altes Passwort",
-      "change_pw": "Passwort ändern"
-    },
     "navigation": {
       "settings": "Einstellungen",
       "display_sats": "Sats anzeigen",
@@ -27,6 +8,13 @@
       "apps": "Anwendungen",
       "home": "Startseite",
       "logout": "Abmelden"
+    },
+    "login": {
+      "enter_pass": "Passwort B eingeben",
+      "enter_pass_placeholder": "Passwort B",
+      "error": "Ein Fehler ist aufgetreten",
+      "invalid_pass": "Ungültiges Passwort",
+      "login": "Anmelden"
     },
     "home": {
       "conn_details": "Verbindungsdetails",
@@ -51,6 +39,18 @@
       "send": "Senden",
       "balance": "Guthaben"
     },
+    "tx": {
+      "comment": "Kommentar",
+      "comment_placeholder": "Optionaler Kommentar",
+      "value": "Wert",
+      "description": "Beschreibung",
+      "date": "Datum",
+      "confirmations": "Bestätigungen",
+      "mempool": "Auf mempool anzeigen",
+      "txid": "Transaktions ID",
+      "tx_details": "Transaktionsdetails",
+      "transactions": "Transaktionen"
+    },
     "apps": {
       "online": "online",
       "offline": "offline",
@@ -65,16 +65,17 @@
       "available": "Verfügbare Anwendungen",
       "installed": "Installiert"
     },
-    "tx": {
-      "comment": "Kommentar",
-      "value": "Wert",
-      "description": "Beschreibung",
-      "date": "Datum",
-      "confirmations": "Bestätigungen",
-      "mempool": "Auf mempool anzeigen",
-      "txid": "Transaktions ID",
-      "tx_details": "Transaktionsdetails",
-      "transactions": "Transaktionen"
+    "settings": {
+      "language": "Sprache",
+      "curr_lang": "Aktuelle Sprache",
+      "confirm": "Bestätigen",
+      "cancel": "Abbrechen",
+      "shutdown": "Herunterfahren",
+      "reboot": "Neu starten",
+      "change": "Ändern",
+      "new_pw": "Neues Passwort",
+      "old_pw": "Altes Passwort",
+      "change_pw": "Passwort ändern"
     },
     "forms": {
       "validation": {
@@ -85,6 +86,9 @@
         "chainAddress": {
           "required": "Bitte gib eine Bitcoin Adresse ein",
           "patternMismatch": "Falsches Adress format"
+        },
+        "chainAmount": {
+          "required": "Bitte gib einen Betrag ein"
         },
         "chainFee": {
           "required": "Bitte gib eine Gebühr ein"

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -81,6 +81,10 @@
         "lnInvoice": {
           "required": "Bitte gib eine Lightning invoice ein",
           "patternMismatch": "Falsches invoice format"
+        },
+        "chainAddress": {
+          "required": "Bitte gib eine Bitocin Adresse ein",
+          "patternMismatch": "Falsches Adress format"
         }
       }
     }

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -70,6 +70,7 @@
       "mempool": "View on mempool",
       "value": "Value",
       "comment": "Comment",
+      "comment_placeholder": "Optional comment",
       "sent": "Transaction sent!",
       "confirm_info": "Please confirm the following transaction"
     },
@@ -108,6 +109,9 @@
         "chainAddress": {
           "required": "Please input a Bitcoin address",
           "patternMismatch": "Wrong address format"
+        },
+        "chainAmount": {
+          "required": "Please input an amount"
         },
         "chainFee": {
           "required": "Please input a fee amount"

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -104,6 +104,13 @@
         "lnInvoice": {
           "required": "Please input a Lightning invoice",
           "patternMismatch": "Wrong invoice format"
+        },
+        "chainAddress": {
+          "required": "Please input a Bitcoin address",
+          "patternMismatch": "Wrong address format"
+        },
+        "chainFee": {
+          "required": "Please input a fee amount"
         }
       }
     }

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -111,7 +111,8 @@
           "patternMismatch": "Wrong address format"
         },
         "chainAmount": {
-          "required": "Please input an amount"
+          "required": "Please input an amount",
+          "max": "Your balance is too low to send this amount"
         },
         "chainFee": {
           "required": "Please input a fee amount"

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,17 @@
 .page-container {
   @apply h-full w-full md:w-10/12 md:ml-auto mb-16 md:mb-0 mt-16 overflow-y-auto transition-colors;
 }
+
+/**
+  * Remove up/down arrows from number intput
+**/
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10685,6 +10685,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-hook-form@^7.20.2:
+  version "7.20.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.20.4.tgz#7c23dcaed54812fba9ac63be0313b7c5d11d2b93"
+  integrity sha512-Nvy6TnNMlBoR+qS8FpA8lrqtGJ4uoi/MRYEgMEdBMY0HwHVuC7wB1sk6wTjg7FjOUt7QqMAP2W/vOhTWbKrtkQ==
+
 react-i18next@^11.14.3:
   version "11.14.3"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.14.3.tgz#b44b5c4d1aadac5211be011827a2830be60f2522"


### PR DESCRIPTION
- [x] create general input-component which will handle label/input/error-message
- [x] switch `SendLn` to use this component
- [x] switch `SendOnChain` inputs
- [x] add validation via [react-hook-form](https://react-hook-form.com/get-started/#IntegratingControlledInputs)
  - This is providing lot's of functionalty you don't want to re-implement by yourself in a *okish hacky* way
  - Check this quick video example: https://www.youtube.com/watch?v=DN8v7_RbVlc
- [x] switch SendLn to use react-hook-form
- [x] switch SendOnChain to use react-hook-form
- [x] switch receive to use react-hook-form
- [x] add tests for
  - [x] `SenOnChain`
  - [x] `receive`
  - [x] input-component
- [x] figure out why the PR shows 14 commits instead of just mine which create the changes. I already merged master
- [x] cleanup types