### PR TITLE
feat(transactioncard): handle zero txs #156

### DIFF
--- a/src/assets/info-circle.svg
+++ b/src/assets/info-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/src/components/Home/TransactionCard/TransactionCard.test.tsx
+++ b/src/components/Home/TransactionCard/TransactionCard.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../../../i18n/test_config";
+import type { Props } from "./TransactionCard";
+import TransactionCard from "./TransactionCard";
+
+const props: Props = {
+  transactions: [],
+  isLoading: false,
+  showDetails: () => {},
+};
+
+describe("TransactionCard", () => {
+  test("if info is being displayed if transactions are empty", async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <TransactionCard {...props} />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText("tx.transactions_none")).toBeInTheDocument();
+  });
+});

--- a/src/components/Home/TransactionCard/TransactionCard.tsx
+++ b/src/components/Home/TransactionCard/TransactionCard.tsx
@@ -7,7 +7,7 @@ import { AppContext } from "../../../store/app-context";
 import LoadingBox from "../../Shared/LoadingBox/LoadingBox";
 import SingleTransaction from "./SingleTransaction/SingleTransaction";
 
-type Props = {
+export type Props = {
   transactions: Transaction[];
   showDetails: (index: number) => void;
   isLoading: boolean;
@@ -16,12 +16,10 @@ type Props = {
 const MAX_ITEMS = 6;
 
 const TransactionCard: FC<Props> = ({
-  /* transactions, */
+  transactions,
   isLoading,
   showDetails,
 }) => {
-  const transactions: Transaction[] = [];
-
   const { t } = useTranslation();
   const { walletLocked } = useContext(AppContext);
   const [page, setPage] = useState(0);
@@ -65,7 +63,7 @@ const TransactionCard: FC<Props> = ({
       <section className="bd-card flex flex-col transition-colors min-h-144 md:min-h-0">
         <h2 className="font-bold text-lg">{t("tx.transactions")}</h2>
 
-        {transactions.length === 0 && <p>...no transactions yet, much sad</p>}
+        {transactions.length === 0 && <p>{t("tx.transactions_none")}</p>}
 
         {transactions.length > 0 && (
           <ul className="mt-auto">

--- a/src/components/Home/TransactionCard/TransactionCard.tsx
+++ b/src/components/Home/TransactionCard/TransactionCard.tsx
@@ -1,6 +1,7 @@
 import { FC, useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ReactComponent as ArrowDownIcon } from "../../../assets/arrow-down.svg";
+import { ReactComponent as InfoCircleIcon } from "../../../assets/info-circle.svg";
 import { ReactComponent as ClosedLockIcon } from "../../../assets/lock-closed.svg";
 import { Transaction } from "../../../models/transaction.model";
 import { AppContext } from "../../../store/app-context";
@@ -63,10 +64,15 @@ const TransactionCard: FC<Props> = ({
       <section className="bd-card flex flex-col transition-colors min-h-144 md:min-h-0">
         <h2 className="font-bold text-lg">{t("tx.transactions")}</h2>
 
-        {transactions.length === 0 && <p>{t("tx.transactions_none")}</p>}
+        {transactions.length === 0 && (
+          <div className="flex justify-center items-center h-full">
+            <InfoCircleIcon className="h-6 w-6" />
+            &nbsp;{t("tx.transactions_none")}
+          </div>
+        )}
 
         {transactions.length > 0 && (
-          <ul className="mt-auto">
+          <ul className="py-5">
             {currentPageTxs.map((transaction: Transaction, index: number) => {
               return (
                 <SingleTransaction
@@ -80,7 +86,7 @@ const TransactionCard: FC<Props> = ({
         )}
 
         {transactions.length > 0 && (
-          <article className="flex justify-around py-5 mt-auto">
+          <div className="flex justify-around py-5 mt-auto">
             <button
               onClick={pageBackwardHandler}
               disabled={page === 0}
@@ -96,7 +102,7 @@ const TransactionCard: FC<Props> = ({
             >
               <ArrowDownIcon className="h-6 w-6 transform -rotate-90" />
             </button>
-          </article>
+          </div>
         )}
       </section>
     </div>

--- a/src/components/Home/TransactionCard/TransactionCard.tsx
+++ b/src/components/Home/TransactionCard/TransactionCard.tsx
@@ -10,32 +10,37 @@ import SingleTransaction from "./SingleTransaction/SingleTransaction";
 type Props = {
   transactions: Transaction[];
   showDetails: (index: number) => void;
+  isLoading: boolean;
 };
 
 const MAX_ITEMS = 6;
 
-const TransactionCard: FC<Props> = ({ transactions, showDetails }) => {
+const TransactionCard: FC<Props> = ({
+  /* transactions, */
+  isLoading,
+  showDetails,
+}) => {
+  const transactions: Transaction[] = [];
+
   const { t } = useTranslation();
   const { walletLocked } = useContext(AppContext);
   const [page, setPage] = useState(0);
 
-  if (transactions.length === 0 && !walletLocked) {
-    return <LoadingBox />;
-  }
-
   if (walletLocked) {
     return (
       <div className="p-5 h-full">
-        <article className="bd-card flex flex-col transition-colors min-h-144 md:min-h-0">
-          <article className="h-full flex justify-center items-center">
-            <div>
-              <ClosedLockIcon className="h-6 w-6" />
-            </div>
+        <div className="bd-card flex flex-col transition-colors min-h-144 md:min-h-0">
+          <div className="h-full flex justify-center items-center">
+            <ClosedLockIcon className="h-6 w-6" />
             WALLET LOCKED
-          </article>
-        </article>
+          </div>
+        </div>
       </div>
     );
+  }
+
+  if (isLoading) {
+    return <LoadingBox />;
   }
 
   const pageForwardHandler = () => {
@@ -46,10 +51,10 @@ const TransactionCard: FC<Props> = ({ transactions, showDetails }) => {
     setPage((p) => p - 1);
   };
 
-  let currentPage = transactions;
+  let currentPageTxs = transactions;
 
   if (transactions.length > MAX_ITEMS) {
-    currentPage = transactions.slice(
+    currentPageTxs = transactions.slice(
       page * MAX_ITEMS,
       page * MAX_ITEMS + MAX_ITEMS
     );
@@ -59,33 +64,42 @@ const TransactionCard: FC<Props> = ({ transactions, showDetails }) => {
     <div className="p-5 h-full">
       <section className="bd-card flex flex-col transition-colors min-h-144 md:min-h-0">
         <h2 className="font-bold text-lg">{t("tx.transactions")}</h2>
-        <ul className="mt-auto">
-          {currentPage.map((transaction: Transaction, index: number) => {
-            return (
-              <SingleTransaction
-                onClick={() => showDetails(transaction.index)}
-                key={index}
-                transaction={transaction}
-              />
-            );
-          })}
-        </ul>
-        <article className="flex justify-around py-5 mt-auto">
-          <button
-            onClick={pageBackwardHandler}
-            disabled={page === 0}
-            className="bg-black hover:bg-gray-700 text-white p-2 rounded flex disabled:opacity-50"
-          >
-            <ArrowDownIcon className="h-6 w-6 transform rotate-90" />
-          </button>
-          <button
-            className="bg-black hover:bg-gray-700 text-white p-2 rounded flex disabled:opacity-50"
-            onClick={pageForwardHandler}
-            disabled={page * MAX_ITEMS + MAX_ITEMS >= transactions.length}
-          >
-            <ArrowDownIcon className="h-6 w-6 transform -rotate-90" />
-          </button>
-        </article>
+
+        {transactions.length === 0 && <p>...no transactions yet, much sad</p>}
+
+        {transactions.length > 0 && (
+          <ul className="mt-auto">
+            {currentPageTxs.map((transaction: Transaction, index: number) => {
+              return (
+                <SingleTransaction
+                  onClick={() => showDetails(transaction.index)}
+                  key={index}
+                  transaction={transaction}
+                />
+              );
+            })}
+          </ul>
+        )}
+
+        {transactions.length > 0 && (
+          <article className="flex justify-around py-5 mt-auto">
+            <button
+              onClick={pageBackwardHandler}
+              disabled={page === 0}
+              className="bg-black hover:bg-gray-700 text-white p-2 rounded flex disabled:opacity-50"
+            >
+              <ArrowDownIcon className="h-6 w-6 transform rotate-90" />
+            </button>
+
+            <button
+              className="bg-black hover:bg-gray-700 text-white p-2 rounded flex disabled:opacity-50"
+              onClick={pageForwardHandler}
+              disabled={page * MAX_ITEMS + MAX_ITEMS >= transactions.length}
+            >
+              <ArrowDownIcon className="h-6 w-6 transform -rotate-90" />
+            </button>
+          </article>
+        )}
       </section>
     </div>
   );

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -78,7 +78,8 @@
       "comment": "Comment",
       "comment_placeholder": "Optional comment",
       "sent": "Transaction sent!",
-      "confirm_info": "Please confirm the following transaction"
+      "confirm_info": "Please confirm the following transaction",
+      "transactions_none": "...no transactions yet, much sad"
     },
     "apps": {
       "installed": "Installed",

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -79,7 +79,7 @@
       "comment_placeholder": "Optional comment",
       "sent": "Transaction sent!",
       "confirm_info": "Please confirm the following transaction",
-      "transactions_none": "...no transactions yet, much sad"
+      "transactions_none": "No transactions yet, much sad"
     },
     "apps": {
       "installed": "Installed",

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -79,7 +79,7 @@
       "comment_placeholder": "Optional comment",
       "sent": "Transaction sent!",
       "confirm_info": "Please confirm the following transaction",
-      "transactions_none": "No transactions yet, much sad"
+      "transactions_none": "No transactions yet, time to make your first one"
     },
     "apps": {
       "installed": "Installed",

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -28,11 +28,14 @@ const Home: FC = () => {
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [detailTx, setDetailTx] = useState<Transaction | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [isLoadingTransactions, setIsLoadingTransactions] = useState(false);
 
   const theme = darkMode ? "dark" : "light";
 
   useEffect(() => {
     if (!walletLocked) {
+      setIsLoadingTransactions(true);
+
       instance
         .get("/lightning/list-all-tx?reversed=true")
         .then((tx: AxiosResponse<Transaction[]>) => {
@@ -43,9 +46,12 @@ const Home: FC = () => {
             setWalletLocked(true);
           }
           // TODO: additional error handling #15
+        })
+        .finally(() => {
+          setIsLoadingTransactions(false);
         });
     }
-  }, [walletLocked, setWalletLocked]);
+  }, [walletLocked, setWalletLocked, setIsLoadingTransactions]);
 
   const showSendModalHandler = useCallback(() => {
     setShowSendModal(true);
@@ -138,6 +144,7 @@ const Home: FC = () => {
         </article>
         <article className="w-full col-span-2 md:col-span-1 xl:col-span-2 row-span-4">
           <TransactionCard
+            isLoading={isLoadingTransactions}
             transactions={transactions}
             showDetails={showDetailHandler}
           />


### PR DESCRIPTION
Current state:  
<img src="https://user-images.githubusercontent.com/1016218/148937099-f493ef31-8f24-4a2e-acdb-a0bef515c5a3.png" width="750">

- [x] tests
- [x] translations  

Aligned transactions to the top because on a big screen they are aligned center and the position jumps if the amount per page isn't equal.

Couldn't get the bitcoin icons not working with a circle, that's why I switched to a heroicon 🤷‍♂️ 