### PR TITLE
chore(ci): check dedupe on audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: |
-              yarn
-              yarn npm audit --environment production
-
+          yarn
+          yarn dedupe --check
+          yarn npm audit --environment production


### PR DESCRIPTION
> Finally, if you want this kind of check to happen on your CI, the -c,--check option will cause the dedupe algorithm to report an error if optimizations would be possible.

https://dev.to/arcanis/yarn-2-2-dedupe-faster-lighter-ha5#dedupe-command