### PR TITLE
feat: add autofocus-prop to inputField and apply

### DIFF
--- a/src/components/Shared/InputField/InputField.tsx
+++ b/src/components/Shared/InputField/InputField.tsx
@@ -1,21 +1,21 @@
+import type { HTMLInputTypeAttribute, ReactElement, Ref } from "react";
 import { forwardRef } from "react";
-import type { ReactElement, Ref } from "react";
 import type { FieldError, UseFormRegisterReturn } from "react-hook-form";
-import type { HTMLInputTypeAttribute } from "react";
 
 const InputField = forwardRef(
   (
     {
-      name,
-      label,
+      autoFocus,
       errorMessage,
-      placeholder,
-      value,
       inputRightAddon,
       inputRightElement,
-      type,
-      textAlign,
+      label,
+      name,
       onChange,
+      placeholder,
+      textAlign,
+      type,
+      value,
       ...rest
     }: InputFieldProps,
     ref: Ref<HTMLInputElement>
@@ -28,19 +28,20 @@ const InputField = forwardRef(
 
         <div className="flex">
           <input
-            id={name}
-            name={name}
-            value={value}
-            type={type}
-            placeholder={placeholder}
             {...rest}
-            ref={ref}
-            onChange={onChange}
+            autoFocus={autoFocus}
             className={`
                ${errorMessage ? "input-error" : "input-underline"}
                ${textAlign === "right" || type === "number" ? "text-right" : ""}
                ${inputRightAddon || inputRightElement ? "w-7/12" : ""}
                `}
+            id={name}
+            name={name}
+            onChange={onChange}
+            placeholder={placeholder}
+            ref={ref}
+            type={type}
+            value={value}
           />
 
           {inputRightAddon && (
@@ -61,6 +62,7 @@ const InputField = forwardRef(
 export default InputField;
 
 export interface InputFieldProps extends UseFormRegisterReturn {
+  autoFocus?: boolean;
   label: string;
   errorMessage?: FieldError;
   placeholder?: string;

--- a/src/components/Shared/UnlockModal/UnlockModal.tsx
+++ b/src/components/Shared/UnlockModal/UnlockModal.tsx
@@ -62,8 +62,9 @@ const UnlockModal: FC<Props> = ({ onClose }) => {
                 {...register("passwordInput", {
                   required: t("forms.validation.unlock.required") as string,
                 })}
-                label={t("forms.validation.unlock.pass_c")}
+                autoFocus
                 errorMessage={errors.passwordInput}
+                label={t("forms.validation.unlock.pass_c")}
                 placeholder={t("forms.validation.unlock.pass_c")}
                 type="password"
               />

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -79,10 +79,11 @@ const Login: FC = () => {
           >
             <label className="label-underline">{t("login.enter_pass")}</label>
             <input
+              autoFocus
+              className="input-underline my-5 w-8/12 md:w-96"
+              placeholder={t("login.enter_pass_placeholder")}
               ref={passwordInput}
               type="password"
-              placeholder={t("login.enter_pass_placeholder")}
-              className="input-underline my-5 w-8/12 md:w-96"
             />
             <button
               type="submit"


### PR DESCRIPTION
Add `autofocus` to login and wallet-unlock.  
It's annoying if the user has to click into the field or use tab to get into the input I believe.  
Also sorted some props A-Z.