### PR TITLE
use-see fixes

### DIFF
--- a/src/components/Navigation/Header/Header.tsx
+++ b/src/components/Navigation/Header/Header.tsx
@@ -4,13 +4,13 @@ import { ReactComponent as MenuIcon } from "../../../assets/menu.svg";
 import { ReactComponent as RaspiBlitzMobileLogo } from "../../../assets/RaspiBlitz_Logo_Icon.svg";
 import { ReactComponent as RaspiBlitzLogo } from "../../../assets/RaspiBlitz_Logo_Main.svg";
 import { ReactComponent as RaspiBlitzLogoDark } from "../../../assets/RaspiBlitz_Logo_Main_Negative.svg";
-import useSSE from "../../../hooks/use-sse";
 import { AppContext } from "../../../store/app-context";
+import { SSEContext } from "../../../store/sse-context";
 import DropdownMenu from "./DropdownMenu/DropdownMenu";
 
 const Header: FC = () => {
   const { darkMode } = useContext(AppContext);
-  const { systemInfo } = useSSE();
+  const { systemInfo } = useContext(SSEContext);
   const dropdown = useRef<HTMLDivElement>(null);
   const menu = useRef<SVGSVGElement>(null);
   const [showDropdown, setShowDropdown] = useState(false);

--- a/src/hooks/use-sse.tsx
+++ b/src/hooks/use-sse.tsx
@@ -18,9 +18,9 @@ function useSSE() {
       setEvtSource(new EventSource(SSE_URL));
     }
 
-    const setApps = (event: Event) => {
+    const setApps = (event: MessageEvent<string>) => {
       sseCtx.setAvailableApps((prev: App[]) => {
-        const apps = JSON.parse((event as MessageEvent<string>).data);
+        const apps = JSON.parse(event.data);
         if (prev.length === 0) {
           return apps;
         } else {
@@ -32,11 +32,9 @@ function useSSE() {
       });
     };
 
-    const setAppStatus = (event: Event) => {
+    const setAppStatus = (event: MessageEvent<string>) => {
       sseCtx.setAppStatus((prev: AppStatus[]) => {
-        const status: AppStatus[] = JSON.parse(
-          (event as MessageEvent<string>).data
-        );
+        const status: AppStatus[] = JSON.parse(event.data);
         if (prev.length === 0) {
           return status;
         } else {
@@ -50,8 +48,8 @@ function useSSE() {
       });
     };
 
-    const setTx = (event: Event) => {
-      const t = JSON.parse((event as MessageEvent<string>).data);
+    const setTx = (event: MessageEvent<string>) => {
+      const t = JSON.parse(event.data);
       sseCtx.setTransactions((prev) => {
         // add the newest transaction to the beginning
         const current = [t, ...prev];
@@ -59,8 +57,8 @@ function useSSE() {
       });
     };
 
-    const setInstall = (event: Event) => {
-      const installEventData = JSON.parse((event as MessageEvent<string>).data);
+    const setInstall = (event: MessageEvent<string>) => {
+      const installEventData = JSON.parse(event.data);
       // {"id": "specter", "mode": "on", "result": "running", "details": ""}
       if (installEventData.result && installEventData.result === "fail") {
         // TODO: replace with a propper Installed Failed Notification
@@ -98,8 +96,8 @@ function useSSE() {
       }
     };
 
-    const setSystemInfo = (event: Event) => {
-      const message = JSON.parse((event as MessageEvent<string>).data);
+    const setSystemInfo = (event: MessageEvent<string>) => {
+      const message = JSON.parse(event.data);
       if (message.alias) {
         setWindowAlias(message.alias);
       }
@@ -111,9 +109,9 @@ function useSSE() {
       });
     };
 
-    const setBtcInfo = (event: Event) => {
+    const setBtcInfo = (event: MessageEvent<string>) => {
       sseCtx.setBtcInfo((prev: BtcInfo) => {
-        const message = JSON.parse((event as MessageEvent<string>).data);
+        const message = JSON.parse(event.data);
 
         return {
           ...prev,
@@ -122,9 +120,9 @@ function useSSE() {
       });
     };
 
-    const setLnStatus = (event: Event) => {
+    const setLnStatus = (event: MessageEvent<string>) => {
       sseCtx.setLnStatus((prev: LnStatus) => {
-        const message = JSON.parse((event as MessageEvent<string>).data);
+        const message = JSON.parse(event.data);
 
         return {
           ...prev,
@@ -133,9 +131,9 @@ function useSSE() {
       });
     };
 
-    const setBalance = (event: Event) => {
+    const setBalance = (event: MessageEvent<string>) => {
       sseCtx.setBalance((prev: WalletBalance) => {
-        const message = JSON.parse((event as MessageEvent<string>).data);
+        const message = JSON.parse(event.data);
 
         return {
           ...prev,
@@ -144,9 +142,9 @@ function useSSE() {
       });
     };
 
-    const setHardwareInfo = (event: Event) => {
+    const setHardwareInfo = (event: MessageEvent<string>) => {
       sseCtx.setHardwareInfo((prev: HardwareInfo | null) => {
-        const message = JSON.parse((event as MessageEvent<string>).data);
+        const message = JSON.parse(event.data);
 
         return {
           ...prev,

--- a/src/hooks/use-sse.tsx
+++ b/src/hooks/use-sse.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect } from "react";
+import { toast } from "react-toastify";
 import { AppStatus } from "../models/app-status";
 import { App } from "../models/app.model";
 import { BtcInfo } from "../models/btc-info";
@@ -58,15 +59,16 @@ function useSSE() {
     };
 
     const setInstall = (event: MessageEvent<string>) => {
+      toast.dismiss();
       const installEventData = JSON.parse(event.data);
       // {"id": "specter", "mode": "on", "result": "running", "details": ""}
       if (installEventData.result && installEventData.result === "fail") {
         // TODO: replace with a propper Installed Failed Notification
         // should be with an OK button so that user can note & report error
         if (installEventData.mode === "on")
-          alert(`Install Failed: ${installEventData.details}`);
+          toast(`Install Failed: ${installEventData.details}`);
         else {
-          alert(`Deinstall Failed: ${installEventData.details}`);
+          toast(`Deinstall Failed: ${installEventData.details}`);
         }
         // set the install context back to null
         sseCtx.setInstallingApp(null);
@@ -80,18 +82,20 @@ function useSSE() {
             installEventData.httpsForced === "1" &&
             installEventData.httpsSelfsigned === "1"
           ) {
-            alert(
+            toast(
               `Install finished :)\n\nYou may need to accept self-signed HTTPS certificate in your browser on first use.`
             );
           } else {
-            alert(`Install finished :)`);
+            toast(`Install finished :)`);
           }
         } else {
-          alert(`Deinstall finished`);
+          toast(`Deinstall finished`);
         }
         // set the install context back to null
+
         sseCtx.setInstallingApp(null);
       } else {
+        toast("START INSTALL", { isLoading: true, autoClose: false });
         sseCtx.setInstallingApp(installEventData);
       }
     };


### PR DESCRIPTION
Merge after #271 

There was a sneaky issue which I didn't realize existed but showed itself thanks to the work from @rootzoll :

In the header & home I used the `useSSE` hook which created 2 Event Listeners on the events instead of one.

With this PR I fixed it by using the `SSEContext` for the Header, which does the same since I don't need a SSE connection for the header, just the info.

Also used toasts instead of the alerts. Will work on that issue more in the coming PRs, so issue #261  is not closed atm.