### PR TITLE
sync screen design improvement

### DIFF
--- a/src/components/Setup/SyncScreen.tsx
+++ b/src/components/Setup/SyncScreen.tsx
@@ -5,6 +5,8 @@ import LoadingSpinner from "../../components/Shared/LoadingSpinner/LoadingSpinne
 import ProgressCircle from "../../container/ProgressCircle/ProgressCircle";
 import SetupContainer from "../../container/SetupContainer/SetupContainer";
 import { instance } from "../../util/interceptor";
+import { ReactComponent as CheckCircleIcon } from "../../assets/check-circle.svg";
+import { ReactComponent as XCircleIcon } from "../../assets/x-circle.svg";
 
 export interface InputData {
   data: SyncData | any;
@@ -79,10 +81,20 @@ const SyncScreen: FC<InputData> = ({ data, callback }) => {
                     <h6 className="text-sm text-gray-500 dark:text-gray-300">
                       {t("home.lightning")}
                     </h6>
-                    <p>
-                      Lightning: ready({data.ln_default_ready}) starts(
-                      {data.system_count_start_lightning})
-                    </p>
+                    <div className="flex justify-around">
+                      <p className="flex gap-2">
+                        {t("setup.started")}:
+                        {data.ln_default_ready === "1" ? (
+                          <CheckCircleIcon className="inline h-6 w-6" />
+                        ) : (
+                          <XCircleIcon className="inline h-6 w-6" />
+                        )}
+                      </p>
+                      <p className="flex">
+                        {t("setup.restarts")}:{" "}
+                        {data.system_count_start_lightning}
+                      </p>
+                    </div>
                   </article>
                 )}
               {data.ln_default &&

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -204,7 +204,9 @@
       "sync_wallet_info": "Please unlock your Lightning Wallet (Password C):",
       "sync_bitcoin_starting": "Starting sync",
       "sync_bitcoin_sync": "Sync Progress",
-      "sync_restartinfo": "(sync will continue on next restart)"
+      "sync_restartinfo": "(sync will continue on next restart)",
+      "started": "Started",
+      "restarts": "Restarts"
     },
     "forms": {
       "hint": {


### PR DESCRIPTION
fixes #249 

Didn't add a debug button but now show the info there directly currently (but with a more fitting description & i18n):

![image](https://user-images.githubusercontent.com/9399034/171914714-3f563361-1aad-4ad4-bba8-c39699c6727f.png)
