### PR TITLE
display modals full-screen on mobile

### DIFF
--- a/src/components/Shared/UnlockModal/UnlockModal.test.tsx
+++ b/src/components/Shared/UnlockModal/UnlockModal.test.tsx
@@ -29,11 +29,13 @@ describe("UnlockModal", () => {
     setup();
 
     const input = screen.getByPlaceholderText("forms.validation.unlock.pass_c");
-    const button = screen.getByRole("button");
+    const button = screen.getByRole("button", {
+      name: "lock-open.svg wallet.unlock",
+    });
     expect(button).toBeDisabled();
 
     await user.type(input, "1234");
-    expect(await screen.findByRole("button")).toBeEnabled();
+    expect(button).toBeEnabled();
   });
 
   test("should show text on wrong password", async () => {

--- a/src/container/ModalDialog/ModalDialog.tsx
+++ b/src/container/ModalDialog/ModalDialog.tsx
@@ -40,18 +40,20 @@ const ModalDialog: FC<Props> = ({ closeable = true, close, children }) => {
 
   return (
     <ModalBackground>
-      <div className="xl:max-w-screen-sm mx-5 flex h-auto max-h-[100%] w-4/5 flex-col overflow-y-auto rounded-lg bg-white pb-4 text-center dark:bg-gray-800 dark:text-white lg:w-1/2 xl:w-2/5">
+      <div className="xl:max-w-screen-sm flex h-screen max-h-[100%] w-screen flex-col overflow-y-auto rounded-lg bg-white pb-4 text-center dark:bg-gray-800 dark:text-white md:h-auto md:w-4/5 lg:w-1/2 xl:mx-5 xl:w-2/5">
         <div className="flex pr-2 pt-1">
-          {closeable && (
-            <button
-              onClick={closeModal}
-              className="ml-auto mt-1 flex h-7 w-7 items-end"
-            >
-              <XIcon className="h-full w-full" />
-            </button>
-          )}
+          <button
+            onClick={closeModal}
+            className={`ml-auto mt-1 flex h-7 w-7 items-end ${
+              closeable ? "" : "invisible"
+            }`}
+          >
+            <XIcon className="h-full w-full" />
+          </button>
         </div>
-        <div className="px-5">{children}</div>
+        <div className="flex h-full flex-col justify-center px-5">
+          {children}
+        </div>
       </div>
     </ModalBackground>
   );


### PR DESCRIPTION
& fix layout shift when hiding the close button

closes #85 

further improvement would be to show the header more on the top, created #413 for it

![after1](https://user-images.githubusercontent.com/9399034/182525508-f71962db-afd4-4411-ade6-4f63e864f3ee.png)

![after2](https://user-images.githubusercontent.com/9399034/182525512-ef080992-973c-438d-8c9c-a45b8618c1b9.png)
![after3](https://user-images.githubusercontent.com/9399034/182525519-10ab967b-a107-408c-b8a2-30764b162f9e.png)
