### PR TITLE
fix: password regex

### DIFF
--- a/src/components/Settings/ChangePwModal/ChangePwModal.tsx
+++ b/src/components/Settings/ChangePwModal/ChangePwModal.tsx
@@ -75,7 +75,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             {...register("oldPassword", {
               required: t("setup.password_error_empty"),
               pattern: {
-                value: /^[a-zA-Z0-9]*$/,
+                value: /^[a-zA-Z0-9\-\.]*$/,
                 message: t("setup.password_error_chars"),
               },
               minLength: {
@@ -94,7 +94,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             {...register("newPassword", {
               required: t("setup.password_error_empty"),
               pattern: {
-                value: /^[a-zA-Z0-9]*$/,
+                value: /^[a-zA-Z0-9\-\.]*$/,
                 message: t("setup.password_error_chars"),
               },
               minLength: {

--- a/src/components/Settings/ChangePwModal/ChangePwModal.tsx
+++ b/src/components/Settings/ChangePwModal/ChangePwModal.tsx
@@ -75,7 +75,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             {...register("oldPassword", {
               required: t("setup.password_error_empty"),
               pattern: {
-                value: /^[a-zA-Z0-9\-\.]*$/,
+                value: /^[a-zA-Z0-9.-]*$/,
                 message: t("setup.password_error_chars"),
               },
               minLength: {
@@ -94,7 +94,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             {...register("newPassword", {
               required: t("setup.password_error_empty"),
               pattern: {
-                value: /^[a-zA-Z0-9\-\.]*$/,
+                value: /^[a-zA-Z0-9.-]*$/,
                 message: t("setup.password_error_chars"),
               },
               minLength: {

--- a/src/components/Setup/InputPassword.tsx
+++ b/src/components/Setup/InputPassword.tsx
@@ -87,7 +87,7 @@ const InputPassword: FC<Props> = ({ passwordType, callback }) => {
                   required: t("setup.password_error_empty"),
                   onChange: changePasswordHandler,
                   pattern: {
-                    value: /^[a-zA-Z0-9]*$/,
+                    value: /^[a-zA-Z0-9\-\.]*$/,
                     message: t("setup.password_error_chars"),
                   },
                   minLength: {

--- a/src/components/Setup/InputPassword.tsx
+++ b/src/components/Setup/InputPassword.tsx
@@ -87,7 +87,7 @@ const InputPassword: FC<Props> = ({ passwordType, callback }) => {
                   required: t("setup.password_error_empty"),
                   onChange: changePasswordHandler,
                   pattern: {
-                    value: /^[a-zA-Z0-9\-\.]*$/,
+                    value: /^[a-zA-Z0-9.-]*$/,
                     message: t("setup.password_error_chars"),
                   },
                   minLength: {


### PR DESCRIPTION
Resolves #415.

Adapts the password regex to be the same as the Raspiblitz uses. See also https://github.com/rootzoll/raspiblitz/issues/3260.

This is just a quick fix, maybe it would make sense to have this as a constant somewhere so as to not repeat the literal regex so often. Might make it cumbersome if it ever needs to be changed--maybe overkill though. Just a thought.