### PR TITLE
make sidebar fixed, show bottom nav on md size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@
 }
 
 .page-container {
-  @apply mb-16 mt-16 h-full w-full overflow-y-auto transition-colors md:ml-auto md:mb-0 md:w-10/12;
+  @apply mb-16 mt-16 h-full w-full overflow-y-auto transition-colors lg:mb-0 lg:w-full lg:pl-64;
 }
 
 /**

--- a/src/layouts/BottomNav.tsx
+++ b/src/layouts/BottomNav.tsx
@@ -14,7 +14,7 @@ const BottomNav: FC = () => {
   const { t } = useTranslation();
 
   return (
-    <footer className="fixed bottom-0 z-10 flex h-16 w-full flex-wrap items-center justify-evenly border-t-2 bg-white shadow-inner transition-colors dark:bg-gray-800 md:hidden">
+    <footer className="fixed bottom-0 z-10 flex h-16 w-full flex-wrap items-center justify-evenly border-t-2 bg-white shadow-inner transition-colors dark:bg-gray-800 lg:hidden">
       <NavLink to="/home" className={(props) => createClassName(props)}>
         <HomeIcon className={navIconClasses} />
         <span className={navLabelClasses}>{t("navigation.home")}</span>

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -11,7 +11,7 @@ import { NavLink } from "react-router-dom";
 import { AppContext } from "../context/app-context";
 
 const navLinkClasses =
-  "flex md:flex-col lg:flex-row items-center justify-center py-4 mx-auto w-full dark:text-white opacity-80";
+  "flex md:flex-col lg:flex-row items-center justify-center py-4 w-full dark:text-white opacity-80";
 const navLinkActiveClasses = "text-yellow-500 dark:text-yellow-500 opacity-100";
 const createClassName = ({ isActive }: { isActive: boolean }) =>
   `${navLinkClasses} ${isActive ? navLinkActiveClasses : ""}`;
@@ -26,27 +26,29 @@ export const SideDrawer: FC = () => {
       <div className="flex flex-col items-center justify-center">
         <NavLink to="/home" className={(props) => createClassName(props)}>
           <HomeIcon className={navIconClasses} />
-          <span className="mx-3 flex w-1/2 justify-center text-lg lg:block">
+          <span className="mx-3 w-1/2 justify-center text-lg">
             {t("navigation.home")}
           </span>
         </NavLink>
         <NavLink to="/apps" className={(props) => createClassName(props)}>
           <ViewGridIcon className={navIconClasses} />
-          <span className="mx-3 flex w-1/2 justify-center text-lg lg:block">
+          <span className="mx-3 w-1/2 justify-center text-lg">
             {t("navigation.apps")}
           </span>
         </NavLink>
         <NavLink to="/settings" className={(props) => createClassName(props)}>
           <CogIcon className={navIconClasses} />
-          <span className="mx-3 flex w-1/2 justify-center text-lg lg:block">
+          <span className="mx-3 w-1/2 justify-center text-lg">
             {t("navigation.settings")}
           </span>
         </NavLink>
       </div>
 
-      <button onClick={logout} className="bd-button mb-3 h-8 w-full">
-        <LogoutIcon className="inline-block h-5 w-5" />
-        &nbsp;
+      <button
+        onClick={logout}
+        className="bd-button mb-3 flex h-8 w-full items-center justify-center"
+      >
+        <LogoutIcon className="mr-1 inline-block h-5 w-5" />
         {t("navigation.logout")}
       </button>
     </nav>

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -11,19 +11,19 @@ import { NavLink } from "react-router-dom";
 import { AppContext } from "../context/app-context";
 
 const navLinkClasses =
-  "flex md:flex-col lg:flex-row items-center justify-center py-4 xl:pl-6 mx-auto w-full dark:text-white opacity-80";
+  "flex md:flex-col lg:flex-row items-center justify-center py-4 mx-auto w-full dark:text-white opacity-80";
 const navLinkActiveClasses = "text-yellow-500 dark:text-yellow-500 opacity-100";
 const createClassName = ({ isActive }: { isActive: boolean }) =>
   `${navLinkClasses} ${isActive ? navLinkActiveClasses : ""}`;
-const navIconClasses = "inline-block w-10 h-10";
+const navIconClasses = "inline w-10 h-10";
 
 export const SideDrawer: FC = () => {
   const { logout } = useContext(AppContext);
   const { t } = useTranslation();
 
   return (
-    <nav className="content-container fixed mb-16 hidden w-full flex-col justify-between bg-white px-2 pt-8 shadow-lg transition-colors dark:bg-gray-800 md:flex md:w-2/12">
-      <div>
+    <nav className="content-container fixed mb-16 hidden w-full flex-col justify-between bg-white px-2 pt-8 shadow-md transition-colors dark:bg-gray-800 lg:flex lg:w-64">
+      <div className="flex flex-col items-center justify-center">
         <NavLink to="/home" className={(props) => createClassName(props)}>
           <HomeIcon className={navIconClasses} />
           <span className="mx-3 flex w-1/2 justify-center text-lg lg:block">
@@ -32,7 +32,7 @@ export const SideDrawer: FC = () => {
         </NavLink>
         <NavLink to="/apps" className={(props) => createClassName(props)}>
           <ViewGridIcon className={navIconClasses} />
-          <span className="mx-3 flex w-full justify-center text-lg lg:block lg:w-1/2">
+          <span className="mx-3 flex w-1/2 justify-center text-lg lg:block">
             {t("navigation.apps")}
           </span>
         </NavLink>


### PR DESCRIPTION
closes #446 

This makes the sidebar fixed, which prevents problems with other languages having longer labels ("apps" => "Anwendungen") thus thus  makes it look better IMO.

In addition, it delays the sidebar to `lg` width which shows the bottom nav on devices like the iPad Air now, which makes for an more app-like experiences on these devices & prevents width issues with the main content.