### PR TITLE
Corrected casing on "LNbits" name and updated repo URL

### DIFF
--- a/src/utils/availableApps.ts
+++ b/src/utils/availableApps.ts
@@ -43,10 +43,10 @@ export const availableApps = new Map([
     "lnbits",
     {
       id: "lnbits",
-      name: "LNBits",
+      name: "LNbits",
       author: "arcbtc",
       version: "v0.8.0",
-      repository: "https://github.com/lnbits/lnbits-legend",
+      repository: "https://github.com/lnbits/lnbits",
     },
   ],
   [


### PR DESCRIPTION
LNbits has a lower case "b". Corrected casing in dashboard from "LNBits" to "LNbits".

Main repo URL has also changed recently. lnbits-legend has moved to lnbits - https://github.com/lnbits/lnbits