### PR TITLE
(SendModal): use num_msat instead of deprecated num_satoshis field

### DIFF
--- a/backend-mock/lightning.js
+++ b/backend-mock/lightning.js
@@ -47,7 +47,7 @@ router.get("/decode-pay-req", (req, res) => {
           "03fd5eeea1e7ef8bf25124e5bb0f4546e1dd28ce09d6c0d5136f417d74e8afb270",
         payment_hash:
           "9909c5899d66b50e27cff3dc69662487b63356aa3c7fae1d5823a43c3c9fe4ef",
-        num_satoshis: 50000,
+        num_satoshis: 50000, // deprecated
         timestamp: 1656845793,
         expiry: 86400,
         description: "",

--- a/src/pages/Home/SendModal/ConfirmSendModal.tsx
+++ b/src/pages/Home/SendModal/ConfirmSendModal.tsx
@@ -12,7 +12,11 @@ import ButtonWithSpinner from "../../../components/ButtonWithSpinner/ButtonWithS
 import Message from "../../../components/Message";
 import { AppContext, Unit } from "../../../context/app-context";
 import { checkError } from "../../../utils/checkError";
-import { convertBtcToSat, stringToNumber } from "../../../utils/format";
+import {
+  convertBtcToSat,
+  convertMSatToSat,
+  stringToNumber,
+} from "../../../utils/format";
 import { instance } from "../../../utils/interceptor";
 import { TxType } from "../SwitchTxType";
 interface IFormInputs {
@@ -20,7 +24,6 @@ interface IFormInputs {
 }
 
 export type Props = {
-  amount: number;
   address: string;
   back: () => void;
   balance: number;
@@ -28,6 +31,7 @@ export type Props = {
   comment: string;
   expiry: number;
   fee: string;
+  /** amount in mSat */
   invoiceAmount: number;
   invoiceType: TxType;
   /** epoch time in seconds */
@@ -35,7 +39,6 @@ export type Props = {
 };
 
 const ConfirmSendModal: FC<Props> = ({
-  amount,
   address,
   back,
   balance,
@@ -157,7 +160,9 @@ const ConfirmSendModal: FC<Props> = ({
 
       <div className="my-2">
         <h4 className="font-bold">{t("wallet.amount")}:</h4>
-        {Number(invoiceAmount) !== 0 && <span>{invoiceAmount} Sat</span>}
+        {Number(invoiceAmount) !== 0 && (
+          <span>{convertMSatToSat(invoiceAmount)} Sat</span>
+        )}
 
         {isInvoiceAmountBiggerThanBalance && (
           <p className="text-red-500">{t("forms.validation.lnInvoice.max")}</p>

--- a/src/pages/Home/SendModal/SendModal.tsx
+++ b/src/pages/Home/SendModal/SendModal.tsx
@@ -38,7 +38,7 @@ const SendModal: FC<Props> = ({ lnBalance, onClose, onchainBalance }) => {
         },
       })
       .then((resp) => {
-        setAmount(resp.data.num_satoshis);
+        setAmount(resp.data.num_msat);
         setComment(resp.data.description);
         setTimestamp(resp.data.timestamp);
         setExpiry(resp.data.expiry);
@@ -92,7 +92,6 @@ const SendModal: FC<Props> = ({ lnBalance, onClose, onchainBalance }) => {
     return (
       <ModalDialog close={() => onClose(false)}>
         <ConfirmSendModal
-          amount={amount}
           address={addr}
           back={() => setConfirm(false)}
           balance={

--- a/src/pages/Home/SendModal/__tests__/ConfirmSendModal.test.tsx
+++ b/src/pages/Home/SendModal/__tests__/ConfirmSendModal.test.tsx
@@ -10,7 +10,6 @@ import ConfirmSendModal from "../ConfirmSendModal";
 const closeSpy = jest.fn();
 
 const basicLnTxProps: Props = {
-  amount: 0,
   address:
     "lnbcrt10u1pscxuktpp5k4hp6wxafdaqfhk84krlt26q80dfdg5df3cdagwjpr5v8xc7s5qqdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2sp5ndav50eqfh32xxpwd4wa645hevumj7ze5meuajjs40vtgkucdams9qy9qsqc34r4wlyytf68xvt540gz7yq80wsdhyy93dgetv2d2x44dhtg4fysu9k8v0aec8r649tcgtu5s9xths93nuxklvf93px6gnlw2h7u0gq602rww",
   back: () => {},
@@ -25,7 +24,6 @@ const basicLnTxProps: Props = {
 };
 
 const basicOnChainTxProps: Props = {
-  amount: 50,
   address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
   back: () => {},
   balance: 100,
@@ -190,11 +188,7 @@ describe("ConfirmSendModal", () => {
     test("show error if amount is bigger than balance", async () => {
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal
-            {...basicOnChainTxProps}
-            invoiceAmount={111}
-            amount={111}
-          />
+          <ConfirmSendModal {...basicOnChainTxProps} invoiceAmount={111} />
         </I18nextProvider>
       );
 
@@ -209,11 +203,7 @@ describe("ConfirmSendModal", () => {
     test("valid form passes", async () => {
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal
-            {...basicOnChainTxProps}
-            amount={50}
-            invoiceAmount={50}
-          />
+          <ConfirmSendModal {...basicOnChainTxProps} invoiceAmount={50} />
         </I18nextProvider>
       );
 

--- a/src/pages/Home/SendModal/__tests__/SendModal.test.tsx
+++ b/src/pages/Home/SendModal/__tests__/SendModal.test.tsx
@@ -160,7 +160,7 @@ describe("SendModal", () => {
       expect(confirmBtn).toBeEnabled();
       await user.click(confirmBtn);
       // Should display confirm modal with amount
-      expect(await screen.findByText("20123 Sat")).toBeInTheDocument();
+      expect(await screen.findByText("20.123 Sat")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
relates to #567 
Also removed the duplicated `amount` field.
Tested with a 5k sat invoice.

Added benefit is also the formatted Invoice amount in the Confirm Modal.