### PR TITLE
Move apps to sidebar

### DIFF
--- a/backend-mock/sse/installed_app_status.js
+++ b/backend-mock/sse/installed_app_status.js
@@ -26,10 +26,12 @@ const appStatus = () => {
     },
     {
       id: "btc-rpc-explorer",
-      installed: false,
+      installed: true,
       version: "v1.0.0",
       status: "offline",
       error: "",
+      address: "http://192.168.1.100:3000",
+      hiddenService: "4pt2ludsdsdns48dwnd2899rqf63pcdwdwdwh7dwaeukn1w.onion",
     },
     {
       id: "btcpayserver",

--- a/package.json
+++ b/package.json
@@ -23,22 +23,6 @@
       "prettier --write"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "**/*.stories.*"
-        ],
-        "rules": {
-          "import/no-anonymous-default-export": "off"
-        }
-      }
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,10 @@
   min-height: calc(100vh - theme("spacing.16"));
 }
 
+.sidebar {
+  max-height: calc(100vh - theme("spacing.16"));
+}
+
 /* Custom Scrollbar Chrome */
 ::-webkit-scrollbar {
   width: 5px;

--- a/src/components/AppIcon.tsx
+++ b/src/components/AppIcon.tsx
@@ -2,12 +2,13 @@ import type { FC } from "react";
 
 type Props = {
   appId: string;
+  className?: string;
 };
 
-const AppIcon: FC<Props> = ({ appId }) => {
+const AppIcon: FC<Props> = ({ appId, className = "" }) => {
   return (
     <img
-      className="max-h-16"
+      className={`${className}`}
       src={`/assets/apps/logos/${appId}.png`}
       onError={(e) => {
         (e.target as HTMLImageElement).src = "/assets/cloud.svg";

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -5,6 +5,7 @@ import {
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
 import { SSEContext } from "context/sse-context";
+import { AppStatus } from "models/app-status";
 import AppStatusCard from "pages/Home/AppStatusCard";
 import type { FC } from "react";
 import { useContext } from "react";
@@ -13,7 +14,7 @@ import { NavLink } from "react-router-dom";
 import { AppContext } from "../context/app-context";
 
 const navLinkClasses =
-  "flex md:flex-col lg:flex-row items-center justify-center py-4 w-full dark:text-white opacity-80";
+  "flex md:flex-col lg:flex-row items-center justify-center py-4 w-full dark:text-white opacity-80 hover:text-yellow-500 dark:hover:text-yellow-500";
 const navLinkActiveClasses = "text-yellow-500 dark:text-yellow-500 opacity-100";
 const createClassName = ({ isActive }: { isActive: boolean }) =>
   `${navLinkClasses} ${isActive ? navLinkActiveClasses : ""}`;

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -1,9 +1,11 @@
 import {
+  ArrowRightOnRectangleIcon,
   Cog6ToothIcon,
   HomeIcon,
-  ArrowRightOnRectangleIcon,
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
+import { SSEContext } from "context/sse-context";
+import AppStatusCard from "pages/Home/AppStatusCard";
 import type { FC } from "react";
 import { useContext } from "react";
 import { useTranslation } from "react-i18next";
@@ -19,10 +21,11 @@ const navIconClasses = "inline w-10 h-10";
 
 export const SideDrawer: FC = () => {
   const { logout } = useContext(AppContext);
+  const { appStatus } = useContext(SSEContext);
   const { t } = useTranslation();
 
   return (
-    <nav className="content-container fixed mb-16 hidden w-full flex-col justify-between bg-white px-2 pt-8 shadow-md transition-colors dark:bg-gray-800 lg:flex lg:w-64">
+    <nav className="content-container sidebar fixed hidden w-full flex-col justify-between overflow-y-scroll bg-white px-2 pb-16 pt-8 shadow-md transition-colors dark:bg-gray-800 lg:flex lg:w-64">
       <div className="flex flex-col items-center justify-center">
         <NavLink to="/home" className={(props) => createClassName(props)}>
           <HomeIcon className={navIconClasses} />
@@ -42,15 +45,22 @@ export const SideDrawer: FC = () => {
             {t("navigation.settings")}
           </span>
         </NavLink>
+        {appStatus
+          .filter((app) => app.installed)
+          .map((app) => (
+            <AppStatusCard app={app} key={app.id} />
+          ))}
       </div>
 
-      <button
-        onClick={logout}
-        className="bd-button mb-3 flex h-8 w-full items-center justify-center"
-      >
-        <ArrowRightOnRectangleIcon className="mr-1 inline-block h-5 w-5" />
-        {t("navigation.logout")}
-      </button>
+      <div className="fixed bottom-0 left-2 z-10 w-60 bg-white dark:bg-gray-800">
+        <button
+          onClick={logout}
+          className="bd-button mb-3 flex h-8 w-60 items-center justify-center"
+        >
+          <ArrowRightOnRectangleIcon className="mr-1 inline-block h-5 w-5" />
+          {t("navigation.logout")}
+        </button>
+      </div>
     </nav>
   );
 };

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -5,7 +5,6 @@ import {
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
 import { SSEContext } from "context/sse-context";
-import { AppStatus } from "models/app-status";
 import AppStatusCard from "pages/Home/AppStatusCard";
 import type { FC } from "react";
 import { useContext } from "react";

--- a/src/pages/Home/AppStatusCard.tsx
+++ b/src/pages/Home/AppStatusCard.tsx
@@ -11,15 +11,22 @@ export const AppStatusCard: FC<Props> = ({ app }) => {
   const { id } = app;
   const appName = availableApps.get(id)?.name;
 
+  const link = window.location.hostname.endsWith(".onion")
+    ? app.hiddenService
+    : app.address;
+
   return (
-    <article className="flex w-full items-center justify-center py-4 opacity-80 dark:text-white md:flex-col lg:flex-row">
+    <a
+      href={link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex w-full cursor-pointer items-center justify-center py-4 opacity-80 hover:text-yellow-500 dark:text-white dark:hover:text-yellow-500 md:flex-col lg:flex-row"
+    >
       {/* Icon */}
       <AppIcon appId={id} className="h-19 inline w-10" />
       {/* Content */}
-      <h4 className=" mx-3 w-1/2 justify-center text-lg dark:text-white">
-        {appName}
-      </h4>
-    </article>
+      <span className="mx-3 w-1/2 justify-center text-lg">{appName}</span>
+    </a>
   );
 };
 

--- a/src/pages/Home/AppStatusCard.tsx
+++ b/src/pages/Home/AppStatusCard.tsx
@@ -12,20 +12,14 @@ export const AppStatusCard: FC<Props> = ({ app }) => {
   const appName = availableApps.get(id)?.name;
 
   return (
-    <div className="h-full">
-      <article className="bd-card flex items-center transition-colors">
-        <div className="my-2 flex w-full flex-row items-center">
-          {/* Icon */}
-          <div className="flex max-h-16 w-1/4 items-center justify-center p-2">
-            <AppIcon appId={id} />
-          </div>
-          {/* Content */}
-          <div className="flex w-3/4 flex-col items-start justify-center pl-5 text-xl">
-            <h4 className="dark:text-white">{appName}</h4>
-          </div>
-        </div>
-      </article>
-    </div>
+    <article className="flex w-full items-center justify-center py-4 opacity-80 dark:text-white md:flex-col lg:flex-row">
+      {/* Icon */}
+      <AppIcon appId={id} className="h-19 inline w-10" />
+      {/* Content */}
+      <h4 className=" mx-3 w-1/2 justify-center text-lg dark:text-white">
+        {appName}
+      </h4>
+    </article>
   );
 };
 

--- a/src/pages/Home/__tests__/AppStatusCard.test.tsx
+++ b/src/pages/Home/__tests__/AppStatusCard.test.tsx
@@ -1,0 +1,41 @@
+import { AppStatus } from "models/app-status";
+import AppStatusCard from "pages/Home/AppStatusCard";
+import { render, screen } from "test-utils";
+
+const testApp: AppStatus = {
+  id: "specter",
+  installed: true,
+  version: "1.0.0",
+  address: "http://127.0.0.1",
+  hiddenService: "http://hiddenservice.onion",
+  error: "",
+};
+
+describe("AppStatusCard", () => {
+  it("should link to 'address'", () => {
+    render(<AppStatusCard app={testApp} />);
+
+    const appCard = screen.getAllByRole("link");
+    expect(appCard[0].getAttribute("href")).toEqual("http://127.0.0.1");
+  });
+
+  it("should link to 'hiddenService' if window.location is an onion address", () => {
+    console.log(global.window);
+    const oldWindow = global.window;
+    global.window = Object.create(window);
+    Object.defineProperty(window, "location", {
+      value: {
+        hostname: "http://someplace.onion",
+      },
+      writable: true,
+    });
+    render(<AppStatusCard app={testApp} />);
+
+    const appCard = screen.getAllByRole("link");
+    console.log(window.location.hostname);
+    expect(appCard[0].getAttribute("href")).toEqual(
+      "http://hiddenservice.onion"
+    );
+    global.window = oldWindow;
+  });
+});

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -6,12 +6,10 @@ import LoadingSpinner from "../../components/LoadingSpinner/LoadingSpinner";
 import { AppContext } from "../../context/app-context";
 import { useInterval } from "../../hooks/use-interval";
 import useSSE from "../../hooks/use-sse";
-import { AppStatus } from "../../models/app-status";
 import { Transaction } from "../../models/transaction.model";
 import { enableGutter } from "../../utils";
 import { checkError } from "../../utils/checkError";
 import { instance } from "../../utils/interceptor";
-import AppStatusCard from "./AppStatusCard";
 import BitcoinCard from "./BitcoinCard";
 import ConnectionCard from "./ConnectionCard";
 import HardwareCard from "./HardwareCard";
@@ -276,18 +274,6 @@ const Home: FC = () => {
             <LightningCard />
           </article>
         )}
-        {appStatus
-          .filter((app: AppStatus) => app.installed)
-          .map((app: AppStatus) => {
-            return (
-              <article
-                key={app.id}
-                className="col-span-2 row-span-1 md:col-span-1"
-              >
-                <AppStatusCard app={app} />
-              </article>
-            );
-          })}
       </main>
     </>
   );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -36,7 +36,7 @@ type ModalType =
 const Home: FC = () => {
   const { t } = useTranslation();
   const { darkMode, walletLocked, setWalletLocked } = useContext(AppContext);
-  const { balance, lnInfoLite, appStatus, systemStartupInfo } = useSSE();
+  const { balance, lnInfoLite, systemStartupInfo } = useSSE();
   const [showModal, setShowModal] = useState<ModalType | false>(false);
   const [detailTx, setDetailTx] = useState<Transaction | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
@@ -227,15 +227,13 @@ const Home: FC = () => {
       </>
     );
   }
-
-  const gridRows = 6 + appStatus.length / 4;
   const height = btcOnlyMode ? "h-full md:h-1/2" : "h-full";
 
   return (
     <>
       {determineModal()}
       <main
-        className={`content-container page-container grid h-full grid-cols-1 gap-5 bg-gray-100 p-5 transition-colors dark:bg-gray-700 dark:text-white lg:gap-8 lg:pt-8 lg:pb-8 lg:pr-8 grid-rows-${gridRows.toFixed()} md:grid-cols-2 xl:grid-cols-4`}
+        className={`content-container page-container grid h-full grid-cols-1 grid-rows-1 gap-5 bg-gray-100 p-5 transition-colors dark:bg-gray-700 dark:text-white md:grid-cols-2 lg:gap-8 lg:pt-8 lg:pb-8 lg:pr-8 xl:grid-cols-4`}
       >
         {!btcOnlyMode && (
           <article className="col-span-2 row-span-2 md:col-span-1 xl:col-span-2">


### PR DESCRIPTION
fixes #470 
Removed the AppStatusCards and added them to the sidebar (desktop only).

It's now also possible to click the apps which open the TOR link (when accessed over TOR) or the local link otherwise.

TODO:

- [x] add Tests

![grafik](https://user-images.githubusercontent.com/9399034/227260921-c9205b1a-ea5d-4249-a27b-a2130cf0867e.png)
