### PR TITLE
add sweep functionality for on-chain; refactor Send components

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -13,9 +13,15 @@ export type Props = {
   amount?: number;
   register: UseFormRegisterReturn;
   errorMessage?: FieldError;
+  disabled?: boolean;
 };
 
-const AmountInput: FC<Props> = ({ amount, register, errorMessage }) => {
+const AmountInput: FC<Props> = ({
+  amount,
+  register,
+  errorMessage,
+  disabled = false,
+}) => {
   const { t } = useTranslation();
   const [amountInput, setAmountInput] = useState<string>(
     amount ? `${amount}` : ""
@@ -71,6 +77,7 @@ const AmountInput: FC<Props> = ({ amount, register, errorMessage }) => {
           type="text"
           value={amountInput}
           onChange={onChangeHandler}
+          disabled={disabled}
         />
         <span
           className="ml-6 flex w-4/12 items-center justify-center rounded p-1 shadow-md dark:bg-gray-600"

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -293,6 +293,7 @@
       "included_block": "Included in Block",
       "mempool": "View on mempool",
       "sent": "Transaction sent!",
+      "spend_all": "Spend all funds",
       "transactions": "Transactions",
       "transactions_none": "No transactions yet, time to make your first one",
       "tx_details": "Transaction Details",

--- a/src/models/decode-pay-req.ts
+++ b/src/models/decode-pay-req.ts
@@ -1,0 +1,17 @@
+export interface DecodePayRequest {
+  destination: string;
+  payment_hash: string;
+  /** epoch time in seconds */
+  timestamp: number;
+  /** number in seconds */
+  expiry: number;
+  description: string;
+  description_hash: string;
+  fallback_addr: string;
+  cltv_expiry: number;
+  route_hints: [];
+  payment_addr: string;
+  num_msat: number;
+  features: [];
+  currency: string;
+}

--- a/src/pages/Home/SendModal/ConfirmSendModal.tsx
+++ b/src/pages/Home/SendModal/ConfirmSendModal.tsx
@@ -29,7 +29,7 @@ interface IFormInputs {
 
 export type Props = {
   confirmData: SendOnChainForm | SendLnForm;
-  back: () => void;
+  back: (data: SendOnChainForm | SendLnForm) => void;
   balance: number;
   close: (confirmed: boolean) => void;
 };
@@ -131,7 +131,8 @@ const ConfirmSendModal: FC<Props> = ({ confirmData, back, balance, close }) => {
   return (
     <form onSubmit={handleSubmit(sendTransactionHandler)}>
       <button
-        onClick={back}
+        type="button"
+        onClick={() => back(confirmData)}
         className="flex items-center justify-center font-bold outline-none"
       >
         <ChevronLeftIcon className="inline-block h-4 w-4" />

--- a/src/pages/Home/SendModal/SendLN.tsx
+++ b/src/pages/Home/SendModal/SendLN.tsx
@@ -1,6 +1,5 @@
 import { ShareIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import AvailableBalance from "components/AvailableBalance";
-import type { ChangeEvent } from "react";
 import { FC } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
@@ -13,32 +12,26 @@ import Message from "../../../components/Message";
 export type Props = {
   lnBalance: number;
   loading: boolean;
-  onConfirm: () => void;
-  onChangeInvoice: (event: ChangeEvent<HTMLInputElement>) => void;
+  onConfirm: (data: LnInvoiceForm) => void;
   error: string;
 };
-interface IFormInputs {
+
+export interface LnInvoiceForm {
   invoiceInput: string;
 }
 
-const SendLn: FC<Props> = ({
-  loading,
-  lnBalance,
-  onConfirm,
-  onChangeInvoice,
-  error,
-}) => {
+const SendLn: FC<Props> = ({ loading, lnBalance, onConfirm, error }) => {
   const { t } = useTranslation();
 
   const {
     register,
     handleSubmit,
     formState: { errors, isValid },
-  } = useForm<IFormInputs>({
+  } = useForm<LnInvoiceForm>({
     mode: "onChange",
   });
 
-  const onSubmit: SubmitHandler<IFormInputs> = (_) => onConfirm();
+  const onSubmit: SubmitHandler<LnInvoiceForm> = (data) => onConfirm(data);
 
   const convertedBalance = lnBalance ? convertMSatToSat(lnBalance) : 0;
 
@@ -55,7 +48,6 @@ const SendLn: FC<Props> = ({
             value: /^(lnbc|lntb)\w+/i,
             message: t("forms.validation.lnInvoice.patternMismatch"),
           },
-          onChange: onChangeInvoice,
         })}
         label={t("wallet.invoice")}
         errorMessage={errors.invoiceInput}

--- a/src/pages/Home/SendModal/SendOnChain.tsx
+++ b/src/pages/Home/SendModal/SendOnChain.tsx
@@ -7,10 +7,12 @@ import { stringToNumber } from "utils/format";
 import AmountInput from "../../../components/AmountInput";
 import InputField from "../../../components/InputField";
 import { TxType } from "../SwitchTxType";
+import { SendLnForm } from "./SendModal";
 
 export type Props = {
   balance: number;
   onConfirm: (data: SendOnChainForm) => void;
+  confirmData?: SendOnChainForm | SendLnForm | null;
 };
 
 export interface SendOnChainForm {
@@ -23,24 +25,36 @@ export interface SendOnChainForm {
   spendAll: boolean;
 }
 
-const SendOnChain: FC<Props> = ({ balance, onConfirm }) => {
+const SendOnChain: FC<Props> = ({ balance, onConfirm, confirmData }) => {
   const { t } = useTranslation();
   const {
     register,
     handleSubmit,
     watch,
+    reset,
     formState: { errors, isValid },
   } = useForm<SendOnChainForm>({
     mode: "onChange",
   });
+  const [updated, setUpdated] = useState(false);
+  const [amount, setAmount] = useState(0);
+
+  if (!updated && confirmData?.invoiceType === TxType.ONCHAIN) {
+    console.log("updating");
+    setUpdated(true);
+    setAmount(confirmData.amount);
+    reset({
+      address: confirmData.address,
+      comment: confirmData.comment,
+      fee: confirmData.fee,
+      spendAll: confirmData.spendAll,
+    });
+  }
 
   const spendAll = watch("spendAll", false);
   const onSubmit: SubmitHandler<SendOnChainForm> = (data) =>
     // overwrite amount to submit number instead of string
     onConfirm({ ...data, invoiceType: TxType.ONCHAIN, amount });
-
-  const [amount, setAmount] = useState(0);
-
   const changeAmountHandler = (event: ChangeEvent<HTMLInputElement>) => {
     setAmount(+event.target.value);
   };

--- a/src/pages/Home/SendModal/SendOnChain.tsx
+++ b/src/pages/Home/SendModal/SendOnChain.tsx
@@ -1,53 +1,49 @@
 import AvailableBalance from "components/AvailableBalance";
-import { ChangeEvent, FC } from "react";
+import { ChangeEvent, FC, useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { stringToNumber } from "utils/format";
 import AmountInput from "../../../components/AmountInput";
 import InputField from "../../../components/InputField";
-import { stringToNumber } from "../../../utils/format";
+import { TxType } from "../SwitchTxType";
 
 export type Props = {
-  address: string;
-  amount: number;
   balance: number;
-  comment: string;
-  fee: string;
-  onChangeAmount: (event: ChangeEvent<HTMLInputElement>) => void;
-  onChangeAddress: (event: ChangeEvent<HTMLInputElement>) => void;
-  onChangeComment: (event: ChangeEvent<HTMLInputElement>) => void;
-  onChangeFee: (event: ChangeEvent<HTMLInputElement>) => void;
-  onConfirm: () => void;
+  onConfirm: (data: SendOnChainForm) => void;
 };
-interface IFormInputs {
-  addressInput: string;
-  feeInput: number;
-  amountInput: string;
-  commentInput: string;
+
+export interface SendOnChainForm {
+  invoiceType: TxType.ONCHAIN;
+  address: string;
+  fee: string;
+  /** amount in satoshi */
+  amount: number;
+  comment: string;
+  spendAll: boolean;
 }
 
-const SendOnChain: FC<Props> = ({
-  amount,
-  address,
-  balance,
-  comment,
-  fee,
-  onChangeAmount,
-  onChangeAddress,
-  onChangeComment,
-  onChangeFee,
-  onConfirm,
-}) => {
+const SendOnChain: FC<Props> = ({ balance, onConfirm }) => {
   const { t } = useTranslation();
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isValid },
-  } = useForm<IFormInputs>({
+  } = useForm<SendOnChainForm>({
     mode: "onChange",
   });
 
-  const onSubmit: SubmitHandler<IFormInputs> = (_data) => onConfirm();
+  const spendAll = watch("spendAll", false);
+  const onSubmit: SubmitHandler<SendOnChainForm> = (data) =>
+    // overwrite amount to submit number instead of string
+    onConfirm({ ...data, invoiceType: TxType.ONCHAIN, amount });
+
+  const [amount, setAmount] = useState(0);
+
+  const changeAmountHandler = (event: ChangeEvent<HTMLInputElement>) => {
+    setAmount(+event.target.value);
+  };
 
   return (
     <form className="px-5" onSubmit={handleSubmit(onSubmit)}>
@@ -58,50 +54,59 @@ const SendOnChain: FC<Props> = ({
       <fieldset className="my-5 flex flex-col items-center justify-center text-center">
         <div className="w-full py-1 md:w-10/12">
           <InputField
-            {...register("addressInput", {
+            {...register("address", {
               required: t("forms.validation.chainAddress.required"),
               pattern: {
                 value: /^(1|3|bc1|tb1|tpub|bcrt)\w+/i,
                 message: t("forms.validation.chainAddress.patternMismatch"),
               },
-              onChange: onChangeAddress,
             })}
             placeholder="bc1..."
             label={t("wallet.address")}
-            errorMessage={errors.addressInput}
-            value={address}
+            errorMessage={errors.address}
           />
         </div>
 
-        <div className="w-full py-1 md:w-10/12">
-          <AmountInput
-            amount={amount}
-            errorMessage={errors?.amountInput}
-            register={register("amountInput", {
-              required: t("forms.validation.chainAmount.required"),
-              max: {
-                value: balance || 0,
-                message: t("forms.validation.chainAmount.max"),
-              },
-              validate: {
-                greaterThanZero: (val) =>
-                  stringToNumber(val) > 0 ||
-                  t("forms.validation.chainAmount.required"),
-              },
-              onChange: onChangeAmount,
-            })}
+        {!spendAll && (
+          <div className="w-full pt-1 md:w-10/12">
+            <AmountInput
+              errorMessage={errors?.amount}
+              disabled={spendAll}
+              amount={amount}
+              register={register("amount", {
+                required: t("forms.validation.chainAmount.required"),
+                max: {
+                  value: balance || 0,
+                  message: t("forms.validation.chainAmount.max"),
+                },
+                validate: {
+                  greaterThanZero: (val) =>
+                    //@ts-ignore
+                    stringToNumber(val) > 0 ||
+                    t("forms.validation.chainAmount.required"),
+                },
+                onChange: changeAmountHandler,
+              })}
+            />
+          </div>
+        )}
+
+        <div className="flex w-full justify-start gap-2 pb-1 md:w-10/12">
+          <InputField
+            {...register("spendAll", {})}
+            label={t("tx.spend_all")}
+            errorMessage={errors.spendAll}
+            type="checkbox"
           />
         </div>
 
         <div className="w-full py-1 md:w-10/12">
           <InputField
-            {...register("feeInput", {
+            {...register("fee", {
               required: t("forms.validation.chainFee.required"),
-              onChange: onChangeFee,
             })}
             label={t("tx.fee")}
-            errorMessage={errors.feeInput}
-            value={fee}
+            errorMessage={errors.fee}
             inputRightAddon="sat / vByte"
             type="number"
           />
@@ -109,17 +114,14 @@ const SendOnChain: FC<Props> = ({
 
         <div className="w-full py-1 md:w-10/12">
           <InputField
-            {...register("commentInput", {
-              onChange: onChangeComment,
-            })}
+            {...register("comment")}
             label={t("tx.comment")}
-            value={comment}
             placeholder={t("tx.comment_placeholder")}
           />
         </div>
       </fieldset>
 
-      <div className="mb-5 inline-block w-4/5 align-top lg:w-3/12">
+      <div className="inline-block w-4/5 align-top lg:w-3/12">
         <button
           type="submit"
           className="bd-button my-3 p-3"

--- a/src/pages/Home/SendModal/__tests__/ConfirmSendModal.test.tsx
+++ b/src/pages/Home/SendModal/__tests__/ConfirmSendModal.test.tsx
@@ -1,39 +1,41 @@
-import { render, screen, waitFor } from "test-utils";
 import userEvent from "@testing-library/user-event";
 import { I18nextProvider } from "react-i18next";
-import { TxType } from "../../SwitchTxType";
+import { render, screen, waitFor } from "test-utils";
 import i18n from "../../../../i18n/test_config";
 import { rest, server } from "../../../../testServer";
+import { TxType } from "../../SwitchTxType";
 import type { Props } from "../ConfirmSendModal";
 import ConfirmSendModal from "../ConfirmSendModal";
+import { SendLnForm } from "../SendModal";
+import { SendOnChainForm } from "../SendOnChain";
 
 const closeSpy = vi.fn();
 
 const basicLnTxProps: Props = {
-  address:
-    "lnbcrt10u1pscxuktpp5k4hp6wxafdaqfhk84krlt26q80dfdg5df3cdagwjpr5v8xc7s5qqdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2sp5ndav50eqfh32xxpwd4wa645hevumj7ze5meuajjs40vtgkucdams9qy9qsqc34r4wlyytf68xvt540gz7yq80wsdhyy93dgetv2d2x44dhtg4fysu9k8v0aec8r649tcgtu5s9xths93nuxklvf93px6gnlw2h7u0gq602rww",
+  confirmData: {
+    address:
+      "lnbcrt10u1pscxuktpp5k4hp6wxafdaqfhk84krlt26q80dfdg5df3cdagwjpr5v8xc7s5qqdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2sp5ndav50eqfh32xxpwd4wa645hevumj7ze5meuajjs40vtgkucdams9qy9qsqc34r4wlyytf68xvt540gz7yq80wsdhyy93dgetv2d2x44dhtg4fysu9k8v0aec8r649tcgtu5s9xths93nuxklvf93px6gnlw2h7u0gq602rww",
+    invoiceType: TxType.LIGHTNING,
+    comment: "",
+    expiry: 36000,
+    amount: 0,
+    timestamp: 1893456000, // 01 Jan 2030 00:00:00 GMT
+  } as SendLnForm,
   back: () => {},
   balance: 100,
   close: closeSpy,
-  comment: "",
-  expiry: 36000,
-  fee: "",
-  invoiceAmount: 0,
-  invoiceType: TxType.LIGHTNING,
-  timestamp: 1893456000, // 01 Jan 2030 00:00:00 GMT
 };
 
 const basicOnChainTxProps: Props = {
-  address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+  confirmData: {
+    address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    fee: "1",
+    amount: 50000,
+    invoiceType: TxType.ONCHAIN,
+  } as SendOnChainForm,
   back: () => {},
   balance: 100,
   close: closeSpy,
-  comment: "",
-  expiry: 36000,
-  fee: "1",
-  invoiceAmount: 50,
-  invoiceType: TxType.ONCHAIN,
-  timestamp: 1893456000, // 01 Jan 2030 00:00:00 GMT
 };
 
 describe("ConfirmSendModal", () => {
@@ -130,13 +132,14 @@ describe("ConfirmSendModal", () => {
 
   describe("ln-invoice with amount above zero", () => {
     test("show error if invoice is expired", async () => {
+      const confirmData = {
+        ...basicLnTxProps.confirmData,
+        timestamp: 1640995200, // Sat Jan 01 2022 08:00:00
+        expiry: 36000,
+      };
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal
-            {...basicLnTxProps}
-            timestamp={1640995200} // "Sat Jan 01 2022 08:00:00
-            expiry={36000}
-          />
+          <ConfirmSendModal {...basicLnTxProps} confirmData={confirmData} />
         </I18nextProvider>
       );
 
@@ -152,9 +155,13 @@ describe("ConfirmSendModal", () => {
     });
 
     test("show error if amount is bigger than balance", async () => {
+      const confirmData = {
+        ...basicLnTxProps.confirmData,
+        amount: 111,
+      };
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal {...basicLnTxProps} invoiceAmount={111} />
+          <ConfirmSendModal {...basicLnTxProps} confirmData={confirmData} />
         </I18nextProvider>
       );
 
@@ -167,9 +174,13 @@ describe("ConfirmSendModal", () => {
     });
 
     test("valid form passes", async () => {
+      const confirmData = {
+        ...basicLnTxProps.confirmData,
+        amount: 100,
+      };
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal {...basicLnTxProps} invoiceAmount={100} />
+          <ConfirmSendModal {...basicLnTxProps} confirmData={confirmData} />
         </I18nextProvider>
       );
 
@@ -186,9 +197,16 @@ describe("ConfirmSendModal", () => {
 
   describe("on chain tx with amount above zero", () => {
     test("show error if amount is bigger than balance", async () => {
+      const confirmData = {
+        ...basicOnChainTxProps.confirmData,
+        amount: 111,
+      };
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal {...basicOnChainTxProps} invoiceAmount={111} />
+          <ConfirmSendModal
+            {...basicOnChainTxProps}
+            confirmData={confirmData}
+          />
         </I18nextProvider>
       );
 
@@ -201,9 +219,16 @@ describe("ConfirmSendModal", () => {
     });
 
     test("valid form passes", async () => {
+      const confirmData = {
+        ...basicOnChainTxProps.confirmData,
+        amount: 50,
+      };
       render(
         <I18nextProvider i18n={i18n}>
-          <ConfirmSendModal {...basicOnChainTxProps} invoiceAmount={50} />
+          <ConfirmSendModal
+            {...basicOnChainTxProps}
+            confirmData={confirmData}
+          />
         </I18nextProvider>
       );
 

--- a/src/pages/Home/SendModal/__tests__/SendModal.test.tsx
+++ b/src/pages/Home/SendModal/__tests__/SendModal.test.tsx
@@ -160,7 +160,7 @@ describe("SendModal", () => {
       expect(confirmBtn).toBeEnabled();
       await user.click(confirmBtn);
       // Should display confirm modal with amount
-      expect(await screen.findByText("20.123 Sat")).toBeInTheDocument();
+      expect(await screen.findByText("20,123 Sat")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
fixes #517 

refactored the send components as well (SendModal, SendOnchain, SendLn), to reduce unnecessary complexity

Will need to test more, maybe refactor a bit more, but should work like this.

TODO: 

- [x] when going back on the ConfirmModal, the entered inputs should not be cleared