### PR TITLE
(OpenChannelModal): optimize styling

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -79,12 +79,12 @@ const AmountInput: FC<Props> = ({
       errorMessage={errorMessage?.message}
       endContent={
         <button
-          className="focus:outline-none"
+          className="focus:outline-none h-full"
           type="button"
           onClick={toggleHandler}
           aria-label="toggle password visibility"
         >
-          <span className="whitespace-nowrap text-small text-default-400">
+          <span className="whitespace-nowrap text-small text-default-foreground">
             {unit}
             <ArrowsRightLeftIcon className="ml-1 inline-block h-5 w-5" />
           </span>

--- a/src/components/AvailableBalance.tsx
+++ b/src/components/AvailableBalance.tsx
@@ -17,13 +17,13 @@ const AvailableBalance: FC<Props> = ({ balance }) => {
       : convertToString(unit, balance);
 
   return (
-    <p className="my-5">
-      <span className="font-bold">
-        {t("wallet.available_balance")}
-        :&nbsp;
-      </span>
-      {convertedBalance} {unit}
-    </p>
+    <div className="rounded-xl  px-4 py-3">
+      <p className="text-xs text-secondary">{t("wallet.available_balance")}</p>
+      <p className="text-lg font-bold">
+        {convertedBalance}{" "}
+        <span className="text-sm font-normal text-secondary">{unit}</span>
+      </p>
+    </div>
   );
 };
 

--- a/src/components/__tests__/AvailableBalance.test.tsx
+++ b/src/components/__tests__/AvailableBalance.test.tsx
@@ -26,8 +26,9 @@ describe("AvailableBalance", () => {
       </I18nextProvider>,
     );
 
-    expect(screen.getByText("wallet.available_balance:")).toBeInTheDocument();
-    expect(screen.getByText(`500,000,000 ${Unit.SAT}`)).toBeInTheDocument();
+    expect(screen.getByText("wallet.available_balance")).toBeInTheDocument();
+    expect(screen.getByText("500,000,000")).toBeInTheDocument();
+    expect(screen.getByText(Unit.SAT)).toBeInTheDocument();
   });
 
   it("renders with BTC unit", () => {
@@ -39,7 +40,8 @@ describe("AvailableBalance", () => {
       </I18nextProvider>,
     );
 
-    expect(screen.getByText("wallet.available_balance:")).toBeInTheDocument();
-    expect(screen.getByText(`5.00000000 ${Unit.BTC}`)).toBeInTheDocument();
+    expect(screen.getByText("wallet.available_balance")).toBeInTheDocument();
+    expect(screen.getByText("5.00000000")).toBeInTheDocument();
+    expect(screen.getByText(Unit.BTC)).toBeInTheDocument();
   });
 });

--- a/src/pages/Home/OpenChannelModal.tsx
+++ b/src/pages/Home/OpenChannelModal.tsx
@@ -104,15 +104,15 @@ export default function OpenChannelModal({ balance, disclosure }: Props) {
                 onChange: changeAmountHandler,
               })}
             />
-            <div className="flex justify-around py-8 md:mx-auto md:w-1/2">
-              <label htmlFor="targetConf" className="font-bold">
+            <div className="flex items-center justify-between rounded-xl px-3 py-3">
+              <label htmlFor="targetConf" className="text-sm text-secondary">
                 {t("tx.fee_rate")}
               </label>
               <select
                 id="targetConf"
                 defaultValue={4}
                 {...register("feeRate")}
-                className="rounded bg-yellow-500 p-1 text-white"
+                className="rounded-lg bg-primary px-3 py-2 text-sm outline-none"
               >
                 <option value={1}>{t("home.urgent")}</option>
                 <option value={4}>{t("home.normal")}</option>


### PR DESCRIPTION
The `AmountInput` fix (centered button + better readability) and `AvailableBalance` are available in the other modals as well (like the send on-chain).

Before:

<img width="515" height="506" alt="grafik" src="https://github.com/user-attachments/assets/d0ef3120-20a8-4081-9ed5-496d86d5b020" />


After:
<img width="515" height="506" alt="grafik" src="https://github.com/user-attachments/assets/a6990a05-9812-4167-a653-5e3527dbff69" />
